### PR TITLE
feat: lago-api#133 add issuer URL into webhooks signatures

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -133,6 +133,7 @@ jobs:
         uses: docker/build-push-action@v2
         env:
           RAILS_ENV: staging
+          API_URL: https://${{ github.event.inputs.preview_name }}-api.staging.getlago.com
         with:
           context: ./api
           push: true
@@ -219,6 +220,3 @@ jobs:
       uses: porter-dev/porter-cli-action@v0.1.0
       with:
         command: create worker --app ${{ github.event.inputs.preview_name }}-clock --source registry --values ./api/porter/env_clock.yaml --image ${{ steps.login-ecr.outputs.registry }}/lago-api-staging:${{ github.event.inputs.api_branch }}
-
-
-      

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -84,6 +84,7 @@ services:
     volumes:
       - $LAGO_PATH/api:/app
     environment:
+      - API_URL=https://api.lago.dev
       - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@db:5432/${POSTGRES_DB:-lago}
       - REDIS_URL=redis://redis:6379
       - SECRET_KEY_BASE=${SECRET_KEY_BASE:-your-secret-key-base-hex-64}
@@ -98,7 +99,7 @@ services:
       - "traefik.http.routers.api.service=api"
       - "traefik.http.routers.api.tls=true"
       - "traefik.http.services.api.loadbalancer.server.port=3000"
-  
+
   api-worker:
     image: api
     container_name: lago_api_worker
@@ -110,6 +111,7 @@ services:
     volumes:
       - $LAGO_PATH/api:/app
     environment:
+      - API_URL=https://api.lago.dev
       - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@db:5432/${POSTGRES_DB:-lago}
       - REDIS_URL=redis://redis:6379
       - SECRET_KEY_BASE=${SECRET_KEY_BASE:-your-secret-key-base-hex-64}
@@ -125,7 +127,7 @@ services:
     volumes:
       - $LAGO_PATH/api:/app
     environment:
+      - API_URL=https://api.lago.dev
       - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@db:5432/${POSTGRES_DB:-lago}
       - REDIS_URL=redis://redis:6379
       - SECRET_KEY_BASE=${SECRET_KEY_BASE:-your-secret-key-base-hex-64}
-  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       - api
     command: ["./scripts/start.worker.sh"]
     environment:
+      - API_URL=${API_URL:-http://localhost:3000}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@db:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-lago}
       - REDIS_URL=redis://redis:${REDIS_PORT:-6379}
       - SECRET_KEY_BASE=${SECRET_KEY_BASE:-your-secret-key-base-hex-64}
@@ -80,6 +81,7 @@ services:
       - api
     command: ["./scripts/start.clock.sh"]
     environment:
+      - API_URL=${API_URL:-http://localhost:3000}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@db:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-lago}
       - REDIS_URL=redis://redis:${REDIS_PORT:-6379}
       - SECRET_KEY_BASE=${SECRET_KEY_BASE:-your-secret-key-base-hex-64}


### PR DESCRIPTION
Related to https://github.com/getlago/lago-api/pull/135 and https://github.com/getlago/lago-api/issues/133

Assigns `API_URL` env variable to API images in order to use it enforce security of the API webhook signatures