### PR TITLE
Correct docker image versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   api:
     container_name: lago-api
-    image: getlago/api:V0.2.0-alpha
+    image: getlago/api:v0.2.0-alpha
     restart: unless-stopped
     depends_on:
       - db
@@ -53,7 +53,7 @@ services:
 
   front:
     container_name: lago-front
-    image: getlago/front:V0.2.0-alpha
+    image: getlago/front:v0.2.0-alpha
     restart: unless-stopped
     depends_on:
       - api
@@ -66,7 +66,7 @@ services:
 
   api-worker:
     container_name: lago-worker
-    image: getlago/api:V0.2.0-alpha
+    image: getlago/api:v0.2.0-alpha
     restart: unless-stopped
     depends_on:
       - api
@@ -85,7 +85,7 @@ services:
 
   api-clock:
     container_name: lago-clock
-    image: getlago/api:V0.2.0-alpha
+    image: getlago/api:v0.2.0-alpha
     restart: unless-stopped
     depends_on:
       - api


### PR DESCRIPTION
At some point in time, the `V` in the version tags [became lowercase](https://hub.docker.com/r/getlago/api/tags) switched between lower/upper-case. This PR fixes the tags in the docker-compose.yml so that deploying actually works.