### PR TITLE
misc: Add redis cache configuration

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -97,6 +97,7 @@ services:
       - LAGO_AWS_S3_REGION=${LAGO_AWS_S3_REGION}
       - LAGO_AWS_S3_BUCKET=${LAGO_AWS_S3_BUCKET}
       - LAGO_PDF_URL=${LAGO_PDF_URL:-http://pdf:3000}
+      - LAGO_REDIS_CACHE_URL=redis://redis:6379
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api_http.rule=Host(`api.lago.dev`)"
@@ -133,6 +134,7 @@ services:
       - LAGO_AWS_S3_REGION=${LAGO_AWS_S3_REGION}
       - LAGO_AWS_S3_BUCKET=${LAGO_AWS_S3_BUCKET}
       - LAGO_PDF_URL=${LAGO_PDF_URL:-http://pdf:3000}
+      - LAGO_REDIS_CACHE_URL=redis://redis:6379
 
   api-clock:
     image: api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - LAGO_AWS_S3_REGION=${LAGO_AWS_S3_REGION}
       - LAGO_AWS_S3_BUCKET=${LAGO_AWS_S3_BUCKET}
       - LAGO_PDF_URL=${LAGO_PDF_URL:-http://pdf:3000}
+      - LAGO_REDIS_CACHE_URL=redis://${LAGO_REDIS_CACHE_HOST:-redis}:${LAGO_REDIS_CACHE_PORT:-6379}
     ports:
       - ${API_PORT:-3000}:3000
 
@@ -94,6 +95,7 @@ services:
       - LAGO_AWS_S3_REGION=${LAGO_AWS_S3_REGION}
       - LAGO_AWS_S3_BUCKET=${LAGO_AWS_S3_BUCKET}
       - LAGO_PDF_URL=${LAGO_PDF_URL:-http://pdf:3000}
+      - LAGO_REDIS_CACHE_URL=redis://${LAGO_REDIS_CACHE_HOST:-redis}:${LAGO_REDIS_CACHE_PORT:-6379}
 
   api-clock:
     container_name: lago-clock


### PR DESCRIPTION
Add environment variable to configure Redis cache.
It will be use to store customer current usage to reduce load on server when requesting usage

Related to https://github.com/getlago/lago-api/issues/316