### PR TITLE
chore: 📡 Allow websockets as entrypoint in traefik for front dev env

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -68,7 +68,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.app.rule=Host(`app.lago.dev`)"
-      - "traefik.http.routers.app.entrypoints=web,websecure"
+      - "traefik.http.routers.app.entrypoints=web,ws,websecure"
       - "traefik.http.routers.app.tls=true"
       - "traefik.http.services.app.loadbalancer.server.port=8080"
 


### PR DESCRIPTION
This MR allows `ws` as a valid traefik entrypoint, for front app in dev mode

It will fix web app hot reloading