### PR TITLE
Add needed Segment environment variables

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -98,6 +98,8 @@ services:
       - LAGO_AWS_S3_BUCKET=${LAGO_AWS_S3_BUCKET}
       - LAGO_PDF_URL=${LAGO_PDF_URL:-http://pdf:3000}
       - LAGO_REDIS_CACHE_URL=redis://redis:6379
+      - SEGMENT_WRITE_KEY=${SEGMENT_WRITE_KEY}
+      - LAGO_DISABLE_SEGMENT=${LAGO_DISABLE_SEGMENT:-true}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api_http.rule=Host(`api.lago.dev`)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       - LAGO_AWS_S3_BUCKET=${LAGO_AWS_S3_BUCKET:-bucket}
       - LAGO_PDF_URL=${LAGO_PDF_URL:-http://pdf:3000}
       - LAGO_REDIS_CACHE_URL=redis://${LAGO_REDIS_CACHE_HOST:-redis}:${LAGO_REDIS_CACHE_PORT:-6379}
+      - LAGO_DISABLE_SEGMENT=${LAGO_DISABLE_SEGMENT}
     ports:
       - ${API_PORT:-3000}:3000
 
@@ -98,6 +99,7 @@ services:
       - LAGO_AWS_S3_BUCKET=${LAGO_AWS_S3_BUCKET:-bucket}
       - LAGO_PDF_URL=${LAGO_PDF_URL:-http://pdf:3000}
       - LAGO_REDIS_CACHE_URL=redis://${LAGO_REDIS_CACHE_HOST:-redis}:${LAGO_REDIS_CACHE_PORT:-6379}
+      - LAGO_DISABLE_SEGMENT=${LAGO_DISABLE_SEGMENT}
 
   api-clock:
     container_name: lago-clock


### PR DESCRIPTION
### Context

We want to track and measure what our users are doing, both on the self-hosted and fully-hosted sides.

### Changes

The goal of this PR is to add:
- `SEGMENT_WRITE_KEY` to define what Segment’s workspace is used (Lago Prod or Lago Staging).
- `LAGO_DISABLE_SEGMENT` to be able to opt-out (disable tracking) from a self-hosted app.

### Notes

- `SEGMENT_WRITE_KEY` is not needed on `docker-compose.yml`.
- `LAGO_DISABLE_SEGMENT` is not needed on `api-clock`.