### PR TITLE
fix(segment): Do not default LAGO_DISABLE_SEGMENT to true

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -100,7 +100,7 @@ services:
       - LAGO_PDF_URL=${LAGO_PDF_URL:-http://pdf:3000}
       - LAGO_REDIS_CACHE_URL=redis://redis:6379
       - SEGMENT_WRITE_KEY=${SEGMENT_WRITE_KEY}
-      - LAGO_DISABLE_SEGMENT=${LAGO_DISABLE_SEGMENT:-true}
+      - LAGO_DISABLE_SEGMENT=${LAGO_DISABLE_SEGMENT}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api_http.rule=Host(`api.lago.dev`)"


### PR DESCRIPTION
### Context

`LAGO_DISABLE_SEGMENT` is an environment variable used to disable tracking on Segment.com

### Changes

The goal of this PR is to remove the default value `"true"` from `docker-compose.dev.yml`.

It permits getting rid of the following errors on API when running specs following [this merged PR](https://github.com/getlago/lago-api/pull/359):
```
NameError: uninitialized constant SEGMENT_CLIENT
```