### PR TITLE
fix: Add missing LAGO_API_URL for api container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - redis
     command: ["./scripts/start.sh"]
     environment:
+      - LAGO_API_URL=${LAGO_API_URL:-http://localhost:3000}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-lago}
       - REDIS_URL=redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
       - SECRET_KEY_BASE=${SECRET_KEY_BASE:-your-secret-key-base-hex-64}


### PR DESCRIPTION
## Context

API container is missing LAGO_API_URL environment variable.

## Description

Downloading an invoice is failing in the default self hosted context due to a missing environment variable.
https://github.com/getlago/lago-api/blob/main/app/models/invoice.rb#L41
