### PR TITLE
fix(docker-compose): add a default value for LAGO_DISABLE_SIGNUP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - API_URL=${LAGO_API_URL:-http://localhost:3000}
       - APP_ENV=${APP_ENV:-production}
       - CODEGEN_API=${LAGO_API_URL:-http://localhost:3000}
-      - LAGO_DISABLE_SIGNUP=${LAGO_DISABLE_SIGNUP}
+      - LAGO_DISABLE_SIGNUP=${LAGO_DISABLE_SIGNUP:-false}
     ports:
       - ${FRONT_PORT:-80}:80
       - 443:443


### PR DESCRIPTION
## Context

App renders a blank page when a process env is not defined

## Description

We add a default value to `LAGO_DISABLE_SIGNUP`

