### PR TITLE
fix(docker): bind ports to localhost

### DIFF
--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -17,7 +17,7 @@ services:
     volumes:
       - lago_postgres_data:/data/postgres
     ports:
-      - ${POSTGRES_PORT:-5432}:5432
+      - 127.0.0.1:${POSTGRES_PORT:-5432}:5432
 
   redis:
     image: redis:6.2-alpine
@@ -26,7 +26,7 @@ services:
     volumes:
       - lago_redis_data:/data
     ports:
-      - ${REDIS_PORT:-6379}:6379
+      - 127.0.0.1:${REDIS_PORT:-6379}:6379
 
   api:
     container_name: lago-api
@@ -68,7 +68,7 @@ services:
       - GOCARDLESS_CLIENT_SECRET=${GOCARDLESS_CLIENT_SECRET}
       - LAGO_OAUTH_PROXY_URL=${LAGO_OAUTH_PROXY_URL}
     ports:
-      - ${API_PORT:-3000}:3000
+      - 127.0.0.1:${API_PORT:-3000}:3000
 
   front:
     container_name: lago-front
@@ -85,8 +85,8 @@ services:
       - LAGO_DISABLE_SIGNUP=${LAGO_DISABLE_SIGNUP}
       - LAGO_OAUTH_PROXY_URL=${LAGO_OAUTH_PROXY_URL}
     ports:
-      - ${FRONT_PORT:-80}:80
-      - 443:443
+      - 127.0.0.1:${FRONT_PORT:-80}:80
+    #  - 127.0.0.1:443:443
     # Using SSL with Let's Encrypt
     # volumes:
     #   - ./extra/nginx-letsencrypt.conf:/etc/nginx/conf.d/default.conf

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,7 +37,7 @@ services:
     volumes:
       - postgres_data:/data/postgres
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
 
   redis:
     image: redis:6.2-alpine
@@ -46,7 +46,7 @@ services:
     volumes:
       - redis_data:/data
     ports:
-      - 6379:6379
+      - 127.0.0.1:6379:6379
 
   front:
     image: front

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - lago_postgres_data:/data/postgres
     ports:
-      - ${POSTGRES_PORT:-5432}:5432
+      - 127.0.0.1:${POSTGRES_PORT:-5432}:5432
 
   redis:
     image: redis:6.2-alpine
@@ -27,7 +27,7 @@ services:
     volumes:
       - lago_redis_data:/data
     ports:
-      - ${REDIS_PORT:-6379}:6379
+      - 127.0.0.1:${REDIS_PORT:-6379}:6379
 
   api:
     container_name: lago-api
@@ -72,7 +72,7 @@ services:
       # If using GCS, you need to put the credentials keyfile here
       #- gcs_keyfile.json:/app/gcs_keyfile.json
     ports:
-      - ${API_PORT:-3000}:3000
+      - 127.0.0.1:${API_PORT:-3000}:3000
 
   front:
     container_name: lago-front
@@ -89,8 +89,8 @@ services:
       - LAGO_DISABLE_SIGNUP=${LAGO_DISABLE_SIGNUP:-false}
       - LAGO_OAUTH_PROXY_URL=https://proxy.getlago.com
     ports:
-      - ${FRONT_PORT:-80}:80
-    #  - 443:443
+      - 127.0.0.1:${FRONT_PORT:-80}:80
+    #  - 127.0.0.1:443:443
     # Using SSL with Let's Encrypt
     # volumes:
     #   - ./extra/nginx-letsencrypt.conf:/etc/nginx/conf.d/default.conf


### PR DESCRIPTION
When exposing ports in docker, unless you bind to a specific host (such as 127.0.0.1) it will punch a hole through the system firewall using iptables (see the frustratingly hidden [docker docs](https://docs.docker.com/engine/reference/commandline/run/#publish-or-expose-port--p---expose) about this). In the case of lago right now that means we're potentially exposing the postgres and redis instances to the world.

I've gone ahead and bound to the localhost port for all the exposed ports.

## Area for discussion
This is really just a start point because it raises something I could do with some input on. So far the front container in particular is exposing on port 80, with an optional disabled 443 port. Are you intending for people to expose this directly without a reverse proxy? I'm assuming this is the case as it looks like it builds on top of an nginx base image I think.

In this case, perhaps we're ok with exposing it, although it feels like a decision that should perhaps be made by the user. If that's the case, how do you feel about the api side? Judging by the fact it doesn't have TLS/SSL configuration commented out along side it I'd assume that would be harder to configure for the API side. Are you intending or expecting people to run a reverse proxy for the API?

Overall, I'm happy to alter the PR as you prefer. For my use-case I'll be running the whole thing behind an nginx proxy but I'm happy to just customise the docker-compose file for my needs and fit your desired use case. I understand involving reverse proxies can be more complicated for users to setup and will make the guide more difficult to follow. I'm just hoping at a minimum we might be able to get the postgres and redis containers locked to 127.0.0.1 to protect others who've not spotted this.

Thanks for taking the time to look at and think about this. The project looks great and I'm looking forward to using it!