### PR TITLE
misc(sentry): Allow custom DSN for lago-front

### DIFF
--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -85,6 +85,7 @@ services:
       - CODEGEN_API=${LAGO_API_URL:-http://localhost:3000}
       - LAGO_DISABLE_SIGNUP=${LAGO_DISABLE_SIGNUP}
       - LAGO_OAUTH_PROXY_URL=${LAGO_OAUTH_PROXY_URL}
+      - SENTRY_DSN=${SENTRY_DSN_FRONT}
     ports:
       - ${FRONT_PORT:-80}:80
       - 443:443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       - CODEGEN_API=${LAGO_API_URL:-http://localhost:3000}
       - LAGO_DISABLE_SIGNUP=${LAGO_DISABLE_SIGNUP:-false}
       - LAGO_OAUTH_PROXY_URL=https://proxy.getlago.com
+      - SENTRY_DSN=${SENTRY_DSN_FRONT}
     ports:
       - ${FRONT_PORT:-80}:80
     #  - 443:443


### PR DESCRIPTION
We want to prevent sharing our sentry DSN token to every customer.

Turning it as an env variable will allow
- our customers to setup their own sentry dsn for their lago instance
- us to properly monitor cloud apps without receiving events from all existing apps

