### PR TITLE
feat(docker-compose): Add Docker Compose healthcheck configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       - db
       - redis
     command: ["./scripts/start.sh"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
     environment:
       - LAGO_API_URL=${LAGO_API_URL:-http://localhost:3000}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-lago}
@@ -123,6 +125,8 @@ services:
     depends_on:
       - api
     command: ["./scripts/start.worker.sh"]
+    healthcheck:
+      test: ["CMD-SHELL", "bundle exec sidekiqmon | grep $(hostname) || exit 1"]
     environment:
       - LAGO_API_URL=${LAGO_API_URL:-http://localhost:3000}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-lago}


### PR DESCRIPTION
#### Description

- [x] Add `healthcheck` to docker-compose for api and api-worker

#### Considerations

`healthcheck` configuration is using default parameters specified [here](https://docs.docker.com/engine/reference/builder/#healthcheck). 
It is up to the Lago Team to specify any other values for these parameters.

Closes getlago/lago-api#853
