### PR TITLE
fix(docker): error in api healthcheck logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,12 @@ services:
       - redis
     command: ["./scripts/start.sh"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      test: curl -f http://localhost:3000/health || exit 1
+      interval: 10s
+      start_period: 30s
+      timeout: 60s
+      # uncomment for a potentially faster startup if you have docker --version > 25.0.0
+      # start_interval: 2s
     environment:
       - LAGO_API_URL=${LAGO_API_URL:-http://localhost:3000}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-lago}
@@ -87,7 +92,8 @@ services:
     # Use this command if you want to use SSL with Let's Encrypt
     # command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     depends_on:
-      - api
+      api:
+        condition: service_healthy
     environment:
       - API_URL=${LAGO_API_URL:-http://localhost:3000}
       - APP_ENV=${APP_ENV:-production}
@@ -123,7 +129,8 @@ services:
     image: getlago/api:v0.54.2-beta
     restart: unless-stopped
     depends_on:
-      - api
+      api:
+        condition: service_healthy
     command: ["./scripts/start.worker.sh"]
     healthcheck:
       test: ["CMD-SHELL", "bundle exec sidekiqmon | grep $(hostname) || exit 1"]
@@ -166,7 +173,8 @@ services:
   #  image: getlago/api:v0.54.1-beta
   #  restart: unless-stopped
   #  depends_on:
-  #    - api
+  #    api:
+  #      condition: service_healthy
   #  command: ["./scripts/start.events.worker.sh"]
   #  environment:
   #    - LAGO_API_URL=${LAGO_API_URL:-http://localhost:3000}
@@ -203,7 +211,8 @@ services:
     image: getlago/api:v0.54.2-beta
     restart: unless-stopped
     depends_on:
-      - api
+      api:
+        condition: service_healthy
     command: ["./scripts/start.clock.sh"]
     environment:
       - LAGO_API_URL=${LAGO_API_URL:-http://localhost:3000}


### PR DESCRIPTION
After working with Jeremy for a little while on a lago api-worker error, we realized that it was likely caused by a race condition on startup using the docker-compose.yml, when the worker started before the api migrations are finished. The `curl` binary was missing from the api image, which was recently [resolved](https://github.com/getlago/lago-api/pull/1621), and this PR points the the healthcheck at the `/health` endpoint and uses the `condition: service_healthy` to enforce that the lago api is healthy befor the lago services that depend on the api start.

DO NOT MERGE this until the lago-api image is > `0.54.2-beta` because this depends the fix mentioned above!