### PR TITLE
Add .rsa_private.pem to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-/traefik/certs/*
 *.code-workspace
-.env
 .DS_Store
+.env
+.rsa_private.pem
 .vscode
 /extra/ssl/certbot
-/extra/ssl/nginx*
 /extra/ssl/dhparam.pem
+/extra/ssl/nginx*
+/traefik/certs/*


### PR DESCRIPTION
It's a private file used in development and test by lago-api
