### PR TITLE
Add platform linux/amd64 to mailhog container

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -224,6 +224,7 @@ services:
     image: mailhog/mailhog
     container_name: lago_mailhog
     restart: unless-stopped
+    platform: linux/amd64
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.mail.rule=Host(`mail.lago.dev`)"


### PR DESCRIPTION
Otherwise I get:

 ! mailhog The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested 0.0s