### PR TITLE
Hotfix: Update Readme to cover a workaround for v1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Distributed under the AGPLv3 License. Read more [here](https://www.getlago.com/b
 3. Make sure Git is installed on your machine.
 
 ### Run the app
+⚠️ **Initial setup on Lago v1.6 with docker compose will fail. A [workaround](https://github.com/getlago/lago/issues/369) is available. Or use v1.5 instead**⚠️
 To start using Lago, run the following commands in a shell:
 
 ```


### PR DESCRIPTION
Initializing v1.6 from scratch will result in a failure.
Workaround is to run v1.5 and migrate to v1.6.

As a hotfix I updated the readme to refer to the issue mentioning this bug with a [workaround covering the migration process](https://github.com/getlago/lago/issues/369).