### PR TITLE
feat: Add Lago license key to Docker

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -171,6 +171,7 @@ services:
       - LAGO_KAFKA_ENRICHED_EVENTS_TOPIC=events_enriched
       - LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP=clickhouse
       - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
+      - LAGO_LICENSE=${LAGO_LICENSE:-}
 
   api-events-worker:
     image: api_deb
@@ -209,6 +210,7 @@ services:
       - LAGO_KAFKA_ENRICHED_EVENTS_TOPIC=events_enriched
       - LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP=clickhouse
       - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
+      - LAGO_LICENSE=${LAGO_LICENSE:-}
 
   api-pdfs-worker:
     image: api_dev
@@ -247,6 +249,7 @@ services:
       - LAGO_KAFKA_ENRICHED_EVENTS_TOPIC=events_enriched
       - LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP=clickhouse
       - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
+      - LAGO_LICENSE=${LAGO_LICENSE:-}
 
   api-clock:
     image: api_dev
@@ -278,6 +281,7 @@ services:
       - LAGO_KAFKA_ENRICHED_EVENTS_TOPIC=events_enriched
       - LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP=clickhouse
       - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
+      - LAGO_LICENSE=${LAGO_LICENSE:-}
 
   pdf:
     image: getlago/lago-gotenberg:7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,6 +169,7 @@ services:
       - LAGO_DISABLE_SEGMENT=${LAGO_DISABLE_SEGMENT}
       - LAGO_DISABLE_WALLET_REFRESH=${LAGO_DISABLE_WALLET_REFRESH}
       - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
+      - LAGO_LICENSE=${LAGO_LICENSE:-}
       # - SIDEKIQ_EVENTS=true
       # - SIDEKIQ_PDFS=true
     volumes:
@@ -215,6 +216,7 @@ services:
   #    - LAGO_DISABLE_WALLET_REFRESH=${LAGO_DISABLE_WALLET_REFRESH}
   #    - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
   #    - SIDEKIQ_EVENTS=true
+  #    - LAGO_LICENSE=${LAGO_LICENSE:-}
 
   # You can uncomment this if you want to use a dedicated Sidekiq worker for the invoices pdf creation.
   # It is recommended if you have a high usage of invoices being created to not impact the other Sidekiq Jobs.
@@ -257,6 +259,7 @@ services:
   #    - LAGO_DISABLE_WALLET_REFRESH=${LAGO_DISABLE_WALLET_REFRESH}
   #    - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
   #    - SIDEKIQ_PDFS=true
+  #    - LAGO_LICENSE=${LAGO_LICENSE:-}
 
   api-clock:
     container_name: lago-clock
@@ -283,6 +286,7 @@ services:
       - ENCRYPTION_DETERMINISTIC_KEY=${LAGO_ENCRYPTION_DETERMINISTIC_KEY:-your-encryption-deterministic-key}
       - ENCRYPTION_KEY_DERIVATION_SALT=${LAGO_ENCRYPTION_KEY_DERIVATION_SALT:-your-encryption-derivation-salt}
       - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
+      - LAGO_LICENSE=${LAGO_LICENSE:-}
 
   pdf:
     image: getlago/lago-gotenberg:7.8.2


### PR DESCRIPTION
## Overview

This pull request introduces the inclusion of the Lago license key into our Docker Compose configuration. By integrating the Lago license directly into our environment variables, we ensure that all related services are authorized automatically on deployments and local development setups.