### PR TITLE
Bump migrate image to 1.8.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,7 +293,7 @@ services:
 
   migrate:
     container_name: lago-migrate
-    image: getlago/api:v1.8.1
+    image: getlago/api:v1.8.2
     depends_on:
       - db
     command: ["./scripts/start.migrate.sh"]


### PR DESCRIPTION
Bump migrate in docker-compose to use v1.8.2 image of lago-api.
