### PR TITLE
Remove obsolete docker-compose.yml version

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 volumes:
   front_node_modules_dev:
   front_dist_dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 volumes:
   lago_postgres_data:
   lago_redis_data:


### PR DESCRIPTION
Remove `docker-compose.yml` obsolete version top-level element.
This top-level element was deprecated in [docker compose spec](https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-and-name-top-level-elements) and now throws a warning.