### PR TITLE
Add missing Google SSO env in docker compose file

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -119,6 +119,8 @@ services:
       - LAGO_KAFKA_ENRICHED_EVENTS_TOPIC=events_enriched
       - LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP=clickhouse
       - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
+      - GOOGLE_AUTH_CLIENT_ID=${GOOGLE_AUTH_CLIENT_ID:-}
+      - GOOGLE_AUTH_CLIENT_SECRET=${GOOGLE_AUTH_CLIENT_SECRET:-}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api_http.rule=Host(`api.lago.dev`)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,8 @@ services:
       - LAGO_OAUTH_PROXY_URL=https://proxy.getlago.com
       - LAGO_LICENSE=${LAGO_LICENSE:-}
       - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
+      - GOOGLE_AUTH_CLIENT_ID=${GOOGLE_AUTH_CLIENT_ID:-}
+      - GOOGLE_AUTH_CLIENT_SECRET=${GOOGLE_AUTH_CLIENT_SECRET:-}
       # - SIDEKIQ_EVENTS=true
       # - SIDEKIQ_PDFS=true
     volumes:


### PR DESCRIPTION
In #374, there is still a pending fix on missing Google SSO environment mapping in docker compose file.