### PR TITLE
misc: Update README to add `--depth 1` to `git clone` for basic usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To start using Lago, run the following commands in a shell:
 #### On a fresh install
 ```bash
 # Get the code
-git clone https://github.com/getlago/lago.git
+git clone --depth 1 https://github.com/getlago/lago.git
 
 # Go to Lago folder
 cd lago


### PR DESCRIPTION
Fixes https://github.com/getlago/lago/issues/399.

 This PR updates the READMED.md to make sure only `lago` repository is downloaded (and not `api` and `front`) with `git clone` command when a user only wants to run Lago