### PR TITLE
misc: fix contribution link for local setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Both issue lists are sorted by total number of comments. While not perfect, numb
 
 #### Local development
 
-Lago Core and all packages can be developed locally. For instructions on how to do this, see the following sections in the [Lago documentation](https://github.com/getlago/lago/wiki):
+Lago Core and all packages can be developed locally. For instructions on how to do this, see the following sections in the [Lago documentation](https://github.com/getlago/lago/wiki/Development-Environment):
 
 ### Pull Requests
 


### PR DESCRIPTION
Fix the contribution link to send directly to the `Development Environment` part when mentioned