### PR TITLE
fix: Migrate script has been renamed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -444,7 +444,7 @@ services:
     depends_on:
       - db
       - redis
-    command: ["./scripts/start.migrate.sh"]
+    command: ["./scripts/migrate.sh"]
     volumes:
       - lago_storage_data:/app/storage
     environment:


### PR DESCRIPTION
# Description

This PR will fix https://github.com/getlago/lago/issues/447 and https://github.com/getlago/lago/issues/448

The migration script was renamed recently in the API repository (see https://github.com/getlago/lago-api/pull/2778) but the docker-compose file was not updated accordingly.