### PR TITLE
fix: change codegen api path

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -70,7 +70,7 @@ services:
       - NODE_ENV=development
       - API_URL=https://api.lago.dev
       - APP_DOMAIN=https://app.lago.dev
-      - CODEGEN_API=https://api.lago.dev/graphql
+      - CODEGEN_API=http://api:3000/graphql
       - LAGO_DISABLE_SIGNUP=${LAGO_DISABLE_SIGNUP:-}
       - NANGO_SECRET_KEY=${NANGO_SECRET_KEY:-}
     labels:


### PR DESCRIPTION
## Context
This PR updates the CODEGEN_API environment variable in the docker-compose.dev.yml file to resolve an issue preventing the frontend Docker container from running yarn codegen.

Previously, the CODEGEN_API was set to https://api.lago.dev/graphql, which was inaccessible within the Docker environment. The new value, http://api:3000/graphql, points to the appropriate internal service and allows yarn codegen to execute successfully.