### PR TITLE
feat(debugging): Add support for breakpoints in dev docker compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -96,6 +96,8 @@ services:
       - path: ./.env.development.default
       - path: ./.env.development
         required: false
+    stdin_open: true
+    tty: true
     environment:
       - DATABASE_TEST_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@db:5432/lago_test
       - GOOGLE_AUTH_CLIENT_ID=${GOOGLE_AUTH_CLIENT_ID:-}
@@ -128,6 +130,8 @@ services:
       - path: ./.env.development.default
       - path: ./.env.development
         required: false
+    stdin_open: true
+    tty: true
 
   api-events-worker:
     <<: *api_worker


### PR DESCRIPTION
This will allow using breakpoints in dev setup.

Steps:
1. Add breakpoint which you prefer in code.
2. Attach to matching docker container, e.g. `docker attach lago_api_dev`.
3. Run the code which will hit the breakpoint.
4. Do your stuff.
5. Once finished you can deattach from container by using `ctrl + P + Q`.