### PR TITLE
misc: Capture startup errors and replace os.Exit with panic

### DIFF
--- a/events_processor/processors/events.go
+++ b/events_processor/processors/events.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/getlago/lago-expression/expression-go"
-	"github.com/getsentry/sentry-go"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -49,7 +48,7 @@ func processEvents(records []*kgo.Record) []*kgo.Record {
 					slog.String("error_code", result.ErrorCode()),
 					slog.String("error", result.ErrorMsg()),
 				)
-				sentry.CaptureException(result.Error())
+				utils.CaptureErrorResult(result)
 
 				go produceToDeadLetterQueue(event, result)
 			}
@@ -183,6 +182,6 @@ func produceToDeadLetterQueue(event models.Event, errorResult utils.AnyResult) {
 
 	if !pushed {
 		logger.Error("error while pushing to dead letter topic", slog.String("topic", eventsDeadLetterQueue.GetTopic()))
-		sentry.CaptureException(errorResult.Error())
+		utils.CaptureErrorResult(errorResult)
 	}
 }

--- a/events_processor/processors/processors.go
+++ b/events_processor/processors/processors.go
@@ -78,21 +78,24 @@ func StartProcessingEvents() {
 	eventsEnrichedProducerResult := initProducer(ctx, "LAGO_KAFKA_ENRICHED_EVENTS_TOPIC")
 	if eventsEnrichedProducerResult.Failure() {
 		logger.Error(eventsEnrichedProducerResult.ErrorMsg())
-		os.Exit(1)
+		utils.CaptureErrorResult(eventsEnrichedProducerResult)
+		panic(eventsEnrichedProducerResult.ErrorMessage())
 	}
 	eventsEnrichedProducer = eventsEnrichedProducerResult.Value()
 
 	eventsInAdvanceProducerResult := initProducer(ctx, "LAGO_KAFKA_EVENTS_CHARGED_IN_ADVANCE_TOPIC")
 	if eventsInAdvanceProducerResult.Failure() {
 		logger.Error(eventsInAdvanceProducerResult.ErrorMsg())
-		os.Exit(1)
+		utils.CaptureErrorResult(eventsInAdvanceProducerResult)
+		panic(eventsInAdvanceProducerResult.ErrorMessage())
 	}
 	eventsInAdvanceProducer = eventsInAdvanceProducerResult.Value()
 
 	eventsDeadLetterQueueResult := initProducer(ctx, "LAGO_KAFKA_EVENTS_DEAD_LETTER_TOPIC")
 	if eventsDeadLetterQueueResult.Failure() {
 		logger.Error(eventsDeadLetterQueueResult.ErrorMsg())
-		os.Exit(1)
+		utils.CaptureErrorResult(eventsDeadLetterQueueResult)
+		panic(eventsDeadLetterQueueResult.ErrorMessage())
 	}
 	eventsDeadLetterQueue = eventsDeadLetterQueueResult.Value()
 
@@ -107,13 +110,15 @@ func StartProcessingEvents() {
 		})
 	if err != nil {
 		logger.Error("Error starting the event consumer", slog.String("error", err.Error()))
-		os.Exit(1)
+		utils.CaptureError(err)
+		panic(err.Error())
 	}
 
 	db, err := database.NewConnection(os.Getenv("DATABASE_URL"))
 	if err != nil {
 		logger.Error("Error connecting to the database", slog.String("error", err.Error()))
-		os.Exit(1)
+		utils.CaptureError(err)
+		panic(err.Error())
 	}
 	apiStore = models.NewApiStore(db)
 

--- a/events_processor/utils/error_tracker.go
+++ b/events_processor/utils/error_tracker.go
@@ -1,0 +1,15 @@
+package utils
+
+import "github.com/getsentry/sentry-go"
+
+func CaptureErrorResult(errResult AnyResult) {
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetExtra("error_code", errResult.ErrorCode())
+		scope.SetExtra("error_message", errResult.ErrorMessage())
+		sentry.CaptureException(errResult.Error())
+	})
+}
+
+func CaptureError(err error) {
+	sentry.CaptureException(err)
+}


### PR DESCRIPTION
This PR:

- Improves the error handling by making sure all errors are sent to Sentry if activated
- Replaces `os.Exist` with `panic` to make sure defered functions are executed before terminating