### PR TITLE
misc: Add failed_at timestamp to dead letter events

### DIFF
--- a/events_processor/models/event.go
+++ b/events_processor/models/event.go
@@ -37,10 +37,11 @@ type EnrichedEvent struct {
 }
 
 type FailedEvent struct {
-	Event               Event  `json:"event"`
-	InitialErrorMessage string `json:"initial_error_message"`
-	ErrorMessage        string `json:"error_message"`
-	ErrorCode           string `json:"error_code"`
+	Event               Event     `json:"event"`
+	InitialErrorMessage string    `json:"initial_error_message"`
+	ErrorMessage        string    `json:"error_message"`
+	ErrorCode           string    `json:"error_code"`
+	FailedAt            time.Time `json:"failed_at"`
 }
 
 func (ev *Event) ToEnrichedEvent() utils.Result[*EnrichedEvent] {

--- a/events_processor/processors/events.go
+++ b/events_processor/processors/events.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/getlago/lago-expression/expression-go"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -169,6 +170,7 @@ func produceToDeadLetterQueue(event models.Event, errorResult utils.AnyResult) {
 		InitialErrorMessage: errorResult.ErrorMsg(),
 		ErrorCode:           errorResult.ErrorCode(),
 		ErrorMessage:        errorResult.ErrorMessage(),
+		FailedAt:            time.Now(),
 	}
 
 	eventJson, err := json.Marshal(failedEvent)


### PR DESCRIPTION
This PR adds a new `failed_at` attribute to the events sent to the dead letter queue