### PR TITLE
chore(deploy): Add docker compose with traefik configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /extra/ssl/dhparam.pem
 /extra/ssl/nginx*
 /traefik/certs/*
+/deploy/letsencrypt

--- a/deploy/.env.traefik.example
+++ b/deploy/.env.traefik.example
@@ -1,0 +1,2 @@
+LAGO_DOMAIN=lago.example
+LAGO_ACME_EMAIL=your_email@example.com

--- a/deploy/.env.traefik.example
+++ b/deploy/.env.traefik.example
@@ -1,2 +1,2 @@
-LAGO_DOMAIN=lago.example
-LAGO_ACME_EMAIL=your_email@example.com
+LAGO_DOMAIN=
+LAGO_ACME_EMAIL=

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,6 +24,34 @@ docker compose up --profile all
 docker compose up -d --profile all
 ```
 
+## Docker Compose Traefik
+
+This configuration provide Traefik as a reverse proxy to ease your deployment.
+It supports SSL with Let's Encrypt. :warning: You need a valid domain (with at least one A or AAA record)!
+
+1. Get the docker compose file
+
+```bash
+curl -o docker-compose.yml https://raw.githubusercontent.com/getlago/lago/main/deploy/docker-compose.traefik.yml
+curl -o .env https://raw.githubusercontent.com/getlago/lago/main/deploy/.env.traefik.example
+```
+
+2. Replace the .env values with yours
+
+```bash
+LAGO_DOMAIN=domain.tld
+LAGO_ACME_EMAIL=email@domain.tld
+```
+
+3. Run the following command to start the project
+
+```bash
+docker compose up --profile all
+
+# If you want to run it in the background
+docker compose up -d --profile all
+```
+
 ## Configuration
 
 ### Profiles

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -65,11 +65,11 @@ while true; do
     if [[ "$choice" =~ ^[1-9][0-9]*$ ]] && (( choice >= 1 && choice <= ${#templates[@]} )); then
         selected="${templates[$((choice-1))]}"
         IFS='|' read -r selected_key selected_desc <<< "$selected"
-        echo ""
-        echo "${GREEN}✅ You selected: ${BOLD}$selected_key${NORMAL}${GREEN} - $selected_desc${NORMAL}"
         break
     else
-        echo "${RED}⚠️ Invalid choice, please try again.${NORMAL}"
+        echo ""
+        echo "${RED}⚠️  Invalid choice, please try again.${NORMAL}"
+        echo ""
     fi
 done
 
@@ -77,11 +77,11 @@ echo ""
 
 # Execute selected deployment
 case "$selected_key" in
-    quickstart)
+    Quickstart)
         echo "${CYAN}🚧 Running quickstart Docker container...${NORMAL}"
         docker run -d --name lago-quickstart -p 3000:3000 -p 80:80 getlago/lago:latest
         ;;
-    production)
-        echo "${RED}⚠️ Production deployment is not available yet."
+    Production)
+        echo "${RED}⚠️  Production deployment is not available yet."
         ;;
 esac

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -61,7 +61,7 @@ done
 echo ""
 
 while true; do
-    read -p "${CYAN}👉 Enter your choice [1-$((${#templates[@]}))]: ${NORMAL}" choice
+    read -p "${CYAN}👉 Enter your choice [1-$((${#templates[@]}))]: ${NORMAL}" choice </dev/tty
     if [[ "$choice" =~ ^[1-9][0-9]*$ ]] && (( choice >= 1 && choice <= ${#templates[@]} )); then
         selected="${templates[$((choice-1))]}"
         IFS='|' read -r selected_key selected_desc <<< "$selected"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+GREEN=$(tput setaf 2)
+CYAN=$(tput setaf 6)
+YELLOW=$(tput setaf 3)
+RED=$(tput setaf 1)
+NORMAL=$(tput sgr0)
+BOLD=$(tput bold)
+
+ENV_FILE=".env"
+
+check_command() {
+    if ! command -v "$1" &> /dev/null; then
+        echo "${RED}❌ Error:${NORMAL} ${BOLD}$1${NORMAL} is not installed."
+        return 1
+    else
+        echo "${GREEN}✅ $1 is installed.${NORMAL}"
+        return 0
+    fi
+}
+
+echo "${CYAN}${BOLD}"
+echo "======================="
+echo "🚀 Lago Deployment 🚀"
+echo "=======================${NORMAL}"
+echo ""
+
+echo "${CYAN}${BOLD}🔍 Checking Dependencies...${NORMAL}"
+check_command docker || MISSING_DOCKER=true
+check_command docker-compose || check_command "docker compose" || MISSING_DOCKER_COMPOSE=true
+
+if [ "$MISSING_DOCKER" = true ] || [ "$MISSING_DOCKER_COMPOSE" = true ]; then
+    echo "${YELLOW}⚠️ Please install missing dependencies:${NORMAL}"
+
+    if [ "$MISSING_DOCKER" = true ]; then
+        echo "👉 Docker: https://docs.docker.com/get-docker/"
+    fi
+
+    if [ "$MISSING_DOCKER_COMPOSE" = true ]; then
+        👉 Docker Compose: https://docs.docker.com/compose/install/
+    fi
+fi
+
+echo ""
+
+templates=(
+    "Quickstart|One-line Docker run command, ideal for testing"
+    "Local|Local installation of Lago, without SSL support"
+    "Light|Light Lago installation, ideal for small production usage"
+    "Production|Coming soon... Optimized Production Setup for scalability and performances"
+)
+
+# Display Templates
+echo "${BOLD}📋 Available Templates:${NORMAL}"
+i=1
+for template in "${templates[@]}"; do
+    IFS='|' read -r key desc <<< "$template"
+    echo "${YELLOW}[$i]${NORMAL} ${BOLD}${key}${NORMAL} - ${desc}"
+    ((i++))
+done
+echo ""
+
+while true; do
+    read -p "${CYAN}👉 Enter your choice [1-$((${#templates[@]}))]: ${NORMAL}" choice
+    if [[ "$choice" =~ ^[1-9][0-9]*$ ]] && (( choice >= 1 && choice <= ${#templates[@]} )); then
+        selected="${templates[$((choice-1))]}"
+        IFS='|' read -r selected_key selected_desc <<< "$selected"
+        echo ""
+        echo "${GREEN}✅ You selected: ${BOLD}$selected_key${NORMAL}${GREEN} - $selected_desc${NORMAL}"
+        break
+    else
+        echo "${RED}⚠️ Invalid choice, please try again.${NORMAL}"
+    fi
+done
+
+echo ""
+
+# Execute selected deployment
+case "$selected_key" in
+    quickstart)
+        echo "${CYAN}🚧 Running quickstart Docker container...${NORMAL}"
+        docker run -d --name lago-quickstart -p 3000:3000 -p 80:80 getlago/lago:latest
+        ;;
+    production)
+        echo "${RED}⚠️ Production deployment is not available yet."
+        ;;
+esac

--- a/deploy/docker-compose.light.yml
+++ b/deploy/docker-compose.light.yml
@@ -1,4 +1,4 @@
-name: lago-traefik
+name: lago-light
 
 volumes:
   lago_rsa_data:

--- a/deploy/docker-compose.traefik.yml
+++ b/deploy/docker-compose.traefik.yml
@@ -1,0 +1,291 @@
+name: lago-local
+
+volumes:
+  lago_rsa_data:
+  lago_postgres_data:
+  lago_redis_data:
+  lago_storage_data:
+
+x-postgres-image: &postgres-image
+  image: postgres:14-alpine
+x-redis-image: &redis-image
+  image: redis:6-alpine
+x-backend-image: &backend-image
+  image: getlago/api:v1.23.0
+x-frontend-image: &frontend-image
+  image: getlago/front:v1.23.0
+
+x-lago-domain: &lago-domain
+  "LAGO_DOMAIN": ${LAGO_DOMAIN}
+
+# TODO: Use only LAGO_DOMAIN
+x-backend-urls: &backend-urls
+  "LAGO_FRONT_URL": https://${LAGO_DOMAIN}
+  "LAGO_API_URL": https://${LAGO_DOMAIN}/api
+
+x-backend-environment: &backend-env
+  "DATABASE_URL": postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-lago}?search_path=${POSTGRES_SCHEMA:-public}
+  "REDIS_URL": redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
+  "REDIS_PASSWORD": ${REDIS_PASSWORD:-}
+  "SECRET_KEY_BASE": ${SECRET_KEY_BASE:-your-secret-key-base-hex-64}
+  "RAILS_ENV": production
+  "RAILS_LOG_TO_STDOUT": ${LAGO_RAILS_STDOUT:-true}
+  "LAGO_RSA_PRIVATE_KEY": ${LAGO_RSA_PRIVATE_KEY:-}
+  "LAGO_SIDEKIQ_WEB": ${LAGO_SIDEKIQ_WEB:-true}
+  "LAGO_ENCRYPTION_PRIMARY_KEY": ${LAGO_ENCRYPTION_PRIMARY_KEY:-your-encryption-primary-key}
+  "LAGO_ENCRYPTION_DETERMINISTIC_KEY": ${LAGO_ENCRYPTION_DETERMINISTIC_KEY:-your-encryption-deterministic-key}
+  "LAGO_ENCRYPTION_KEY_DERIVATION_SALT": ${LAGO_ENCRYPTION_KEY_DERIVATION_SALT:-your-encryption-derivation-salt}
+  "LAGO_USE_AWS_S3": ${LAGO_USE_AWS_S3:-false}
+  "LAGO_AWS_S3_ACCESS_KEY_ID": ${LAGO_AWS_S3_ACCESS_KEY_ID:-azerty123456}
+  "LAGO_AWS_S3_SECRET_ACCESS_KEY": ${LAGO_AWS_S3_SECRET_ACCESS_KEY:-azerty123456}
+  "LAGO_AWS_S3_REGION": ${LAGO_AWS_S3_REGION:-us-east-1}
+  "LAGO_AWS_S3_BUCKET": ${LAGO_AWS_S3_BUCKET:-bucket}
+  "LAGO_AWS_S3_ENDPOINT": ${LAGO_AWS_S3_ENDPOINT:-}
+  "LAGO_USE_GCS": ${LAGO_USE_GCS:-false}
+  "LAGO_GCS_PROJECT": ${LAGO_GCS_PROJECT:-}
+  "LAGO_GCS_BUCKET": ${LAGO_GCS_BUCKET:-}
+  "LAGO_FROM_EMAIL": ${LAGO_FROM_EMAIL:-}
+  "LAGO_SMTP_ADDRESS": ${LAGO_SMTP_ADDRESS:-}
+  "LAGO_SMTP_PORT": ${LAGO_SMTP_PORT:-587}
+  "LAGO_SMTP_USERNAME": ${LAGO_SMTP_USERNAME:-}
+  "LAGO_SMTP_PASSWORD": ${LAGO_SMTP_PASSWORD:-}
+  "LAGO_PDF_URL": http://pdf:3000
+  "LAGO_REDIS_CACHE_URL": redis://${LAGO_REDIS_CACHE_HOST:-redis}:${LAGO_REDIS_CACHE_PORT:-6379}
+  "LAGO_REDIS_CACHE_PASSWORD": ${LAGO_REDIS_CACHE_PASSWORD:-}
+  "LAGO_DISABLE_SEGMENT": ${LAGO_DISABLE_SEGMENT:-}
+  "LAGO_DISABLE_WALLET_REFRESH": ${LAGO_DISABLE_WALLET_REFRESH:-}
+  "LAGO_DISABLE_SIGNUP": ${LAGO_DISABLE_SIGNUP:-false}
+  "LAGO_OAUTH_PROXY_URL": https://proxy.getlago.com
+  "LAGO_LICENSE": ${LAGO_LICENSE:-}
+  "LAGO_CREATE_ORG": ${LAGO_CREATE_ORG:-false}
+  "LAGO_ORG_USER_PASSWORD": ${LAGO_ORG_USER_PASSWORD:-}
+  "LAGO_ORG_USER_EMAIL": ${LAGO_ORG_USER_EMAIL:-}
+  "LAGO_ORG_NAME": ${LAGO_ORG_NAME:-}
+  "LAGO_ORG_API_KEY": ${LAGO_ORG_API_KEY:-}
+  "GOOGLE_AUTH_CLIENT_ID": ${GOOGLE_AUTH_CLIENT_ID:-}
+  "GOOGLE_AUTH_CLIENT_SECRET": ${GOOGLE_AUTH_CLIENT_SECRET:-}
+
+x-frontend-environment: &frontend-env
+  "API_URL": "https://${LAGO_DOMAIN}"
+  "APP_ENV": production
+  "LAGO_OAUTH_PROXY_URL": https://proxy.getlago.com
+
+services:
+  traefik:
+    image: traefik:v3.3
+    container_name: lago-traefik
+    restart: unless-stopped
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.email=${LAGO_ACME_EMAIL:-your_email@example.com}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.letsencrypt.acme.caServer=https://acme-staging-v02.api.letsencrypt.org/directory"
+    ports:
+      - 8080:8080
+      - 443:443
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "./letsencrypt:/letsencrypt"
+      
+  db:
+    <<: *postgres-image
+    container_name: lago-db
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:-lago} -d ${POSTGRES_DB:-lago} -h localhost -p ${POSTGRES_PORT:-5432}",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-lago}
+      POSTGRES_USER: ${POSTGRES_USER:-lago}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      PGDATA: /data/postgres
+      PGPORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_SCHEMA: public
+    volumes:
+      - lago_postgres_data:/data/postgres
+    ports:
+      - ${POSTGRES_PORT:-5432}:${POSTGRES_PORT:-5432}
+    profiles:
+      - all
+      - all-no-redis
+      - all-no-keys
+
+  redis:
+    <<: *redis-image
+    container_name: lago-redis
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    command: --port ${REDIS_PORT:-6379}
+    volumes:
+      - lago_redis_data:/data
+    ports:
+      - ${REDIS_PORT:-6379}:${REDIS_PORT:-6379}
+    profiles:
+      - all
+      - all-no-pg
+      - all-no-keys
+
+  rsa-keys:
+    <<: *backend-image
+    container_name: lago-rsa-keys
+    command: ["./scripts/generate.rsa.sh"]
+    volumes:
+      - lago_rsa_data:/app/config/keys
+    profiles:
+      - all
+      - all-no-pg
+      - all-no-redis
+      - all-no-db
+
+  migrate:
+    <<: *backend-image
+    container_name: lago-migrate
+    restart: no
+    depends_on:
+      db:
+        condition: service_healthy
+        restart: true
+        required: false
+    command: ["./scripts/migrate.sh"]
+    volumes:
+      - lago_rsa_data:/app/config/keys
+    environment:
+      <<: *backend-env
+
+  api:
+    <<: *backend-image
+    container_name: lago-api
+    restart: unless-stopped
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+        restart: true
+        required: false
+      redis:
+        condition: service_healthy
+        restart: true
+        required: false
+    command: ["./scripts/start.api.sh"]
+    healthcheck:
+      test: curl -f http://localhost:3000/health || exit 1
+      interval: 10s
+      start_period: 30s
+      timeout: 60s
+      start_interval: 2s
+    environment:
+      <<: [*backend-env, *backend-urls]
+    volumes:
+      - lago_storage_data:/app/storage
+      - lago_rsa_data:/app/config/keys
+    labels:
+      - "traefik.enable=true"
+
+      # API Routes
+      - "traefik.http.routers.lago-api.priority=100"
+      - "traefik.http.routers.lago-api.entrypoints=websecure"
+      - "traefik.http.routers.lago-api.rule=Host(`${LAGO_DOMAIN}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.lago-api.middlewares=lago-api-stripprefix"
+      - "traefik.http.middlewares.lago-api-stripprefix.stripprefix.prefixes=/api"
+      - "traefik.http.routers.lago-api.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.lago-api.service=lago-api-service"
+      - "traefik.http.services.lago-api-service.loadbalancer.server.port=3000"
+
+      # GraphQL Routes
+      - "traefik.http.routers.lago-graphql.priority=100"
+      - "traefik.http.routers.lago-graphql.entrypoints=websecure"
+      - "traefik.http.routers.lago-graphql.rule=Host(`${LAGO_DOMAIN}`) && Path(`/graphql`)"
+      - "traefik.http.routers.lago-graphql.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.lago-graphql.service=lago-api-service"
+
+  front:
+    <<: *frontend-image
+    container_name: lago-front
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+        restart: true
+    environment:
+      <<: [*frontend-env]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.lago-front.priority=50"
+      - "traefik.http.routers.lago-front.entrypoints=websecure"
+      - "traefik.http.routers.lago-front.rule=Host(`${LAGO_DOMAIN}`)"
+      - "traefik.http.routers.lago-front.tls.certresolver=letsencrypt"
+      - "traefik.http.services.lago-front.loadbalancer.server.port=80"
+      
+
+  api-worker:
+    <<: *backend-image
+    container_name: lago-worker
+    restart: unless-stopped
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+        restart: true
+        required: false
+      redis:
+        condition: service_healthy
+        restart: true
+        required: false
+    command: ["./scripts/start.worker.sh"]
+    healthcheck:
+      test: curl -f http://localhost:8080 || exit 1
+      interval: 10s
+      start_period: 30s
+      timeout: 60s
+      start_interval: 2s
+    environment:
+      <<: [*backend-env, *backend-urls]
+    volumes:
+      - lago_storage_data:/app/storage
+      - lago_rsa_data:/app/config/keys
+
+  api-clock:
+    <<: *backend-image
+    container_name: lago-clock
+    restart: unless-stopped
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+        restart: true
+        required: false
+      redis:
+        condition: service_healthy
+        restart: true
+        required: false
+    command: ["./scripts/start.clock.sh"]
+    volumes:
+      - lago_rsa_data:/app/config/keys
+    environment:
+      <<: [*backend-env, *backend-urls]
+
+  pdf:
+    image: getlago/lago-gotenberg:8.15
+    command:
+      - gotenberg
+      - --libreoffice-disable-routes=true
+      - --chromium-ignore-certificate-errors=true
+      - --chromium-disable-javascript=true
+      - --api-timeout=300s

--- a/deploy/docker-compose.traefik.yml
+++ b/deploy/docker-compose.traefik.yml
@@ -199,12 +199,26 @@ services:
       # API Routes
       - "traefik.http.routers.lago-api.priority=100"
       - "traefik.http.routers.lago-api.entrypoints=websecure"
-      - "traefik.http.routers.lago-api.rule=Host(`${LAGO_DOMAIN}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.lago-api.rule=Host(`${LAGO_DOMAIN}`) && PathPrefix(`/api/`)"
       - "traefik.http.routers.lago-api.middlewares=lago-api-stripprefix"
       - "traefik.http.middlewares.lago-api-stripprefix.stripprefix.prefixes=/api"
       - "traefik.http.routers.lago-api.tls.certresolver=letsencrypt"
       - "traefik.http.routers.lago-api.service=lago-api-service"
       - "traefik.http.services.lago-api-service.loadbalancer.server.port=3000"
+
+      # API Versioned Routes
+      - "traefik.http.routers.lago-api-versioned.priority=110"
+      - "traefik.http.routers.lago-api-versioned.entrypoints=websecure"
+      - "traefik.http.routers.lago-api-versioned.rule=Host(`${LAGO_DOMAIN}`) && PathPrefix(`/api/v`)"
+      - "traefik.http.routers.lago-api-versioned.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.lago-api-versioned.service=lago-api-service"
+
+      # API Rails Assets
+      - "traefik.http.routers.lago-api-rails.priority=100"
+      - "traefik.http.routers.lago-api-rails.entrypoints=websecure"
+      - "traefik.http.routers.lago-api-rails.rule=Host(`${LAGO_DOMAIN}`) && PathPrefix(`/rails`)"
+      - "traefik.http.routers.lago-api-rails.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.lago-api-rails.service=lago-api-service"
 
       # GraphQL Routes
       - "traefik.http.routers.lago-graphql.priority=100"

--- a/deploy/docker-compose.traefik.yml
+++ b/deploy/docker-compose.traefik.yml
@@ -1,4 +1,4 @@
-name: lago-local
+name: lago-traefik
 
 volumes:
   lago_rsa_data:


### PR DESCRIPTION
- Add a new docker compose with traefik and SSL support
- Only one domain is used:
  - `api` is exposed on `domain.tld/api`
  - `graphql` is exposed on `domain.tld/graphql`
- Traefik will manage certs with lets encrypt, a valid domain is required!