### PR TITLE
misc: Improve events-processor

### DIFF
--- a/.github/workflows/build-processors-image.yaml
+++ b/.github/workflows/build-processors-image.yaml
@@ -3,7 +3,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "events_processor/**"
   workflow_dispatch:
+
 jobs:
   build-processor-image:
     runs-on: ubuntu-latest

--- a/events_processor/config/kafka/consumer.go
+++ b/events_processor/config/kafka/consumer.go
@@ -9,7 +9,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/otel/attribute"
 
-	tracer "github.com/getlago/lago/events-processors/config"
+	tracer "github.com/getlago/lago/events-processor/config"
 )
 
 type ConsumerGroupConfig struct {

--- a/events_processor/config/kafka/producer.go
+++ b/events_processor/config/kafka/producer.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kgo"
 
-	tracer "github.com/getlago/lago/events-processors/config"
+	tracer "github.com/getlago/lago/events-processor/config"
 )
 
 type ProducerConfig struct {

--- a/events_processor/go.mod
+++ b/events_processor/go.mod
@@ -1,4 +1,4 @@
-module github.com/getlago/lago/events-processors
+module github.com/getlago/lago/events-processor
 
 go 1.24.0
 

--- a/events_processor/main.go
+++ b/events_processor/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 
-	"github.com/getlago/lago/events-processors/processors"
+	"github.com/getlago/lago/events-processor/processors"
 )
 
 func main() {

--- a/events_processor/models/billable_metrics.go
+++ b/events_processor/models/billable_metrics.go
@@ -5,7 +5,7 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/getlago/lago/events-processors/utils"
+	"github.com/getlago/lago/events-processor/utils"
 )
 
 type BillableMetric struct {

--- a/events_processor/models/charges.go
+++ b/events_processor/models/charges.go
@@ -5,7 +5,7 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/getlago/lago/events-processors/utils"
+	"github.com/getlago/lago/events-processor/utils"
 )
 
 type Charge struct {

--- a/events_processor/models/event.go
+++ b/events_processor/models/event.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/getlago/lago/events-processors/utils"
+	"github.com/getlago/lago/events-processor/utils"
 )
 
 const HTTP_RUBY string = "http_ruby"

--- a/events_processor/models/models.go
+++ b/events_processor/models/models.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/getlago/lago/events-processors/config/database"
+	"github.com/getlago/lago/events-processor/config/database"
 )
 
 type ApiStore struct {

--- a/events_processor/models/models_test.go
+++ b/events_processor/models/models_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
-	"github.com/getlago/lago/events-processors/tests"
+	"github.com/getlago/lago/events-processor/tests"
 )
 
 func setupApiStore(t *testing.T) (*ApiStore, sqlmock.Sqlmock, func()) {

--- a/events_processor/models/subscriptions.go
+++ b/events_processor/models/subscriptions.go
@@ -6,7 +6,7 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/getlago/lago/events-processors/utils"
+	"github.com/getlago/lago/events-processor/utils"
 )
 
 type Subscription struct {

--- a/events_processor/processors/events.go
+++ b/events_processor/processors/events.go
@@ -12,10 +12,10 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/otel/attribute"
 
-	tracer "github.com/getlago/lago/events-processors/config"
-	"github.com/getlago/lago/events-processors/config/kafka"
-	"github.com/getlago/lago/events-processors/models"
-	"github.com/getlago/lago/events-processors/utils"
+	tracer "github.com/getlago/lago/events-processor/config"
+	"github.com/getlago/lago/events-processor/config/kafka"
+	"github.com/getlago/lago/events-processor/models"
+	"github.com/getlago/lago/events-processor/utils"
 )
 
 func processEvents(records []*kgo.Record) []*kgo.Record {

--- a/events_processor/processors/events_test.go
+++ b/events_processor/processors/events_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 
-	"github.com/getlago/lago/events-processors/models"
-	"github.com/getlago/lago/events-processors/utils"
+	"github.com/getlago/lago/events-processor/models"
+	"github.com/getlago/lago/events-processor/utils"
 
-	"github.com/getlago/lago/events-processors/tests"
+	"github.com/getlago/lago/events-processor/tests"
 )
 
 func setupTestEnv(t *testing.T) (sqlmock.Sqlmock, func()) {

--- a/events_processor/processors/processors.go
+++ b/events_processor/processors/processors.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kgo"
 
-	tracer "github.com/getlago/lago/events-processors/config"
-	"github.com/getlago/lago/events-processors/config/database"
-	"github.com/getlago/lago/events-processors/config/kafka"
-	"github.com/getlago/lago/events-processors/models"
-	"github.com/getlago/lago/events-processors/utils"
+	tracer "github.com/getlago/lago/events-processor/config"
+	"github.com/getlago/lago/events-processor/config/database"
+	"github.com/getlago/lago/events-processor/config/kafka"
+	"github.com/getlago/lago/events-processor/models"
+	"github.com/getlago/lago/events-processor/utils"
 )
 
 var (

--- a/events_processor/tests/mocked_producer.go
+++ b/events_processor/tests/mocked_producer.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"context"
 
-	"github.com/getlago/lago/events-processors/config/kafka"
+	"github.com/getlago/lago/events-processor/config/kafka"
 )
 
 type MockMessageProducer struct {

--- a/events_processor/tests/mocked_store.go
+++ b/events_processor/tests/mocked_store.go
@@ -8,7 +8,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"gorm.io/driver/postgres"
 
-	"github.com/getlago/lago/events-processors/config/database"
+	"github.com/getlago/lago/events-processor/config/database"
 )
 
 func SetupMockStore(t *testing.T) (*database.DB, sqlmock.Sqlmock, func()) {


### PR DESCRIPTION
This PR:
- fixes the module name in the events-processor project by removing the trailing s to ensure it matches the folder name
- Build the image of the events-processor application when merged in main only when something is changed in the `events-processor` folder. It will still be possible to force a manual build using the GIthub action