### PR TITLE
misc(processor): Makes db max connection configurable

### DIFF
--- a/.env.development.default
+++ b/.env.development.default
@@ -25,6 +25,7 @@ REDIS_URL=redis://redis:6379
 LAGO_REDIS_CACHE_URL=redis://redis:6379
 LAGO_PDF_URL=http://pdf:3000
 LAGO_DATA_API_URL=http://data_api
+LAGO_EVENTS_PROCESSOR_DATABASE_MAX_CONNEXIONS=200
 
 # Misc
 LAGO_FROM_EMAIL=noreply@getlago.com

--- a/events-processor/config/database/database.go
+++ b/events-processor/config/database/database.go
@@ -17,16 +17,21 @@ type DB struct {
 	pool       *pgxpool.Pool
 }
 
-func NewConnection(dbUrl string) (*DB, error) {
+type DBConfig struct {
+	Url      string
+	MaxConns int32
+}
+
+func NewConnection(config DBConfig) (*DB, error) {
 	logger := slog.Default()
 	logger = logger.With("component", "db")
 
-	poolConfig, err := pgxpool.ParseConfig(dbUrl)
+	poolConfig, err := pgxpool.ParseConfig(config.Url)
 	if err != nil {
 		return nil, err
 	}
 
-	poolConfig.MaxConns = 200
+	poolConfig.MaxConns = config.MaxConns
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
 	if err != nil {

--- a/events-processor/config/database/database_test.go
+++ b/events-processor/config/database/database_test.go
@@ -8,10 +8,17 @@ import (
 )
 
 func TestNewConnection(t *testing.T) {
-	_, err := NewConnection("invalid connection")
+	config := DBConfig{
+		Url:      "invalid connection",
+		MaxConns: 200,
+	}
+
+	_, err := NewConnection(config)
 	assert.Error(t, err)
 
-	db, err := NewConnection(os.Getenv("DATABASE_URL"))
+	config.Url = os.Getenv("DATABASE_URL")
+
+	db, err := NewConnection(config)
 	assert.NoError(t, err)
 	assert.NotNil(t, db)
 	assert.NotNil(t, db.Connection)


### PR DESCRIPTION
This PR adds a new `LAGO_EVENTS_PROCESSOR_DATABASE_MAX_CONNEXIONS` env variable to allow us to configure the maximum number of database connection use by the `events-processor`