### PR TITLE
feat(event): handle in advance using source metadata payload

### DIFF
--- a/events-processor/models/event_test.go
+++ b/events-processor/models/event_test.go
@@ -54,3 +54,34 @@ func TestToEnrichedEvent(t *testing.T) {
 		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-03T13:03:29Z\": invalid syntax", result.ErrorMsg())
 	})
 }
+
+func TestShouldCheckInAdvanceBilling(t *testing.T) {
+	t.Run("When event source is not HTTP_RUBY", func(t *testing.T) {
+		event := Event{
+			Source: "REDPANDA_CONNECT",
+		}
+
+		assert.True(t, event.ShouldCheckInAdvanceBilling())
+	})
+
+	t.Run("When event source is HTTP_RUBY without source metadata", func(t *testing.T) {
+		event := Event{
+			Source: HTTP_RUBY,
+		}
+
+		assert.True(t, event.ShouldCheckInAdvanceBilling())
+	})
+
+	t.Run("When event source is HTTP_RUBY with source metadata", func(t *testing.T) {
+		event := Event{
+			Source: HTTP_RUBY,
+			SourceMetadata: &SourceMetadata{
+				ApiPostProcess: true,
+			},
+		}
+		assert.False(t, event.ShouldCheckInAdvanceBilling())
+
+		event.SourceMetadata.ApiPostProcess = false
+		assert.True(t, event.ShouldCheckInAdvanceBilling())
+	})
+}

--- a/events-processor/processors/events.go
+++ b/events-processor/processors/events.go
@@ -80,9 +80,11 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 	}
 	sub := subResult.Value()
 
-	expressionResult := evaluateExpression(enrichedEvent, bm)
-	if expressionResult.Failure() {
-		return failedResult(expressionResult, "evaluate_expression", "Error evaluating custom expression")
+	if event.Source != models.HTTP_RUBY {
+		expressionResult := evaluateExpression(enrichedEvent, bm)
+		if expressionResult.Failure() {
+			return failedResult(expressionResult, "evaluate_expression", "Error evaluating custom expression")
+		}
 	}
 
 	var value = fmt.Sprintf("%v", event.Properties[bm.FieldName])

--- a/events-processor/processors/events.go
+++ b/events-processor/processors/events.go
@@ -74,18 +74,23 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 	}
 	bm := bmResult.Value()
 
-	if event.Source != models.HTTP_RUBY {
-		subResult := apiStore.FetchSubscription(event.OrganizationID, event.ExternalSubscriptionID, enrichedEvent.Time)
-		if subResult.Failure() {
-			return failedResult(subResult, "fetch_subscription", "Error fetching subscription")
-		}
-		sub := subResult.Value()
+	subResult := apiStore.FetchSubscription(event.OrganizationID, event.ExternalSubscriptionID, enrichedEvent.Time)
+	if subResult.Failure() {
+		return failedResult(subResult, "fetch_subscription", "Error fetching subscription")
+	}
+	sub := subResult.Value()
 
-		expressionResult := evaluateExpression(enrichedEvent, bm)
-		if expressionResult.Failure() {
-			return failedResult(expressionResult, "evaluate_expression", "Error evaluating custom expression")
-		}
+	expressionResult := evaluateExpression(enrichedEvent, bm)
+	if expressionResult.Failure() {
+		return failedResult(expressionResult, "evaluate_expression", "Error evaluating custom expression")
+	}
 
+	var value = fmt.Sprintf("%v", event.Properties[bm.FieldName])
+	enrichedEvent.Value = &value
+
+	go produceEnrichedEvent(enrichedEvent)
+
+	if event.ShouldCheckInAdvanceBilling() {
 		hasInAdvanceChargeResult := apiStore.AnyInAdvanceCharge(sub.PlanID, bm.ID)
 		if hasInAdvanceChargeResult.Failure() {
 			return failedResult(hasInAdvanceChargeResult, "fetch_in_advance_charges", "Error fetching in advance charges")
@@ -95,10 +100,6 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 			go produceChargedInAdvanceEvent(enrichedEvent)
 		}
 	}
-
-	var value = fmt.Sprintf("%v", event.Properties[bm.FieldName])
-	enrichedEvent.Value = &value
-	go produceEnrichedEvent(enrichedEvent)
 
 	return utils.SuccessResult(enrichedEvent)
 }

--- a/events-processor/processors/events_test.go
+++ b/events-processor/processors/events_test.go
@@ -75,7 +75,7 @@ func TestProcessEvent(t *testing.T) {
 		assert.Equal(t, "Error fetching billable metric", result.ErrorMessage())
 	})
 
-	t.Run("When event source is HTTP_RUBY", func(t *testing.T) {
+	t.Run("When event source is post processed on API", func(t *testing.T) {
 		sqlmock, delete := setupTestEnv(t)
 		defer delete()
 
@@ -90,6 +90,9 @@ func TestProcessEvent(t *testing.T) {
 			Timestamp:              1741007009,
 			Source:                 models.HTTP_RUBY,
 			Properties:             properties,
+			SourceMetadata: &models.SourceMetadata{
+				ApiPostProcess: true,
+			},
 		}
 
 		bm := models.BillableMetric{
@@ -102,6 +105,9 @@ func TestProcessEvent(t *testing.T) {
 			UpdatedAt:      time.Now(),
 		}
 		mockBmLookup(sqlmock, &bm)
+
+		sub := models.Subscription{ID: "sub123"}
+		mockSubscriptionLookup(sqlmock, &sub)
 
 		enrichedProducer := tests.MockMessageProducer{}
 		eventsEnrichedProducer = &enrichedProducer
@@ -117,7 +123,7 @@ func TestProcessEvent(t *testing.T) {
 		assert.Equal(t, 1, enrichedProducer.ExecutionCount)
 	})
 
-	t.Run("When event source is not HTTP_RUBY when timestamp is invalid", func(t *testing.T) {
+	t.Run("When event source is not post process on API when timestamp is invalid", func(t *testing.T) {
 		sqlmock, delete := setupTestEnv(t)
 		defer delete()
 
@@ -147,7 +153,7 @@ func TestProcessEvent(t *testing.T) {
 		assert.Equal(t, "Error while converting event to enriched event", result.ErrorMessage())
 	})
 
-	t.Run("When event source is not HTTP_RUBY when no subscriptions are found", func(t *testing.T) {
+	t.Run("When event source is not post process on API when no subscriptions are found", func(t *testing.T) {
 		sqlmock, delete := setupTestEnv(t)
 		defer delete()
 
@@ -179,7 +185,7 @@ func TestProcessEvent(t *testing.T) {
 		assert.Equal(t, "Error fetching subscription", result.ErrorMessage())
 	})
 
-	t.Run("When event source is not HTTP_RUBY when expression failed to evaluate", func(t *testing.T) {
+	t.Run("When event source is not post process on API when expression failed to evaluate", func(t *testing.T) {
 		sqlmock, delete := setupTestEnv(t)
 		defer delete()
 
@@ -217,7 +223,7 @@ func TestProcessEvent(t *testing.T) {
 		assert.Equal(t, "Error evaluating custom expression", result.ErrorMessage())
 	})
 
-	t.Run("When event source is not HTTP_RUBY and events belongs to an in advance charge", func(t *testing.T) {
+	t.Run("When event source is not post process on API and events belongs to an in advance charge", func(t *testing.T) {
 		sqlmock, delete := setupTestEnv(t)
 		defer delete()
 


### PR DESCRIPTION
This PR is related to https://github.com/getlago/lago-api/pull/3364

It check the presence of the `ApiPostProcess` in the event's`SourceMetadata` to check if the enriched events should be sent back to the API events consumer via kafka to process the pay in advance logic.