### PR TITLE
misc(processor): Avoid capturing not found errors

### DIFF
--- a/events-processor/models/models.go
+++ b/events-processor/models/models.go
@@ -4,6 +4,8 @@ import (
 	"github.com/getlago/lago/events-processor/config/database"
 )
 
+const ERROR_NOT_FOUND string = "record not found"
+
 type ApiStore struct {
 	db *database.DB
 }

--- a/events-processor/processors/events.go
+++ b/events-processor/processors/events.go
@@ -84,7 +84,12 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 
 	subResult := apiStore.FetchSubscription(event.OrganizationID, event.ExternalSubscriptionID, enrichedEvent.Time)
 	if subResult.Failure() {
-		return failedResult(subResult, "fetch_subscription", "Error fetching subscription")
+		return failedResultWithOptionalCapture(
+			subResult,
+			"fetch_subscription",
+			"Error fetching subscription",
+			subResult.ErrorMsg() != models.ERROR_NOT_FOUND,
+		)
 	}
 	sub := subResult.Value()
 

--- a/events-processor/processors/events.go
+++ b/events-processor/processors/events.go
@@ -49,7 +49,10 @@ func processEvents(records []*kgo.Record) []*kgo.Record {
 					slog.String("error_code", result.ErrorCode()),
 					slog.String("error", result.ErrorMsg()),
 				)
-				utils.CaptureErrorResult(result)
+
+				if result.ErrorDetails().Capture {
+					utils.CaptureErrorResult(result)
+				}
 
 				go produceToDeadLetterQueue(event, result)
 			}
@@ -70,7 +73,12 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 
 	bmResult := apiStore.FetchBillableMetric(event.OrganizationID, event.Code)
 	if bmResult.Failure() {
-		return failedResult(bmResult, "fetch_billable_metric", "Error fetching billable metric")
+		return failedResultWithOptionalCapture(
+			bmResult,
+			"fetch_billable_metric",
+			"Error fetching billable metric",
+			bmResult.ErrorMsg() != models.ERROR_NOT_FOUND,
+		)
 	}
 	bm := bmResult.Value()
 
@@ -107,7 +115,11 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 }
 
 func failedResult(r utils.AnyResult, code string, message string) utils.Result[*models.EnrichedEvent] {
-	return utils.FailedResult[*models.EnrichedEvent](r.Error()).AddErrorDetails(code, message)
+	return utils.FailedResult[*models.EnrichedEvent](r.Error()).AddErrorDetails(code, message, true)
+}
+
+func failedResultWithOptionalCapture(r utils.AnyResult, code string, message string, capture bool) utils.Result[*models.EnrichedEvent] {
+	return utils.FailedResult[*models.EnrichedEvent](r.Error()).AddErrorDetails(code, message, capture)
 }
 
 func evaluateExpression(ev *models.EnrichedEvent, bm *models.BillableMetric) utils.Result[bool] {

--- a/events-processor/utils/result.go
+++ b/events-processor/utils/result.go
@@ -9,6 +9,7 @@ type Result[T any] struct {
 type ErrorDetails struct {
 	Code    string
 	Message string
+	Capture bool
 }
 
 type AnyResult interface {
@@ -52,10 +53,11 @@ func (r Result[T]) ErrorMsg() string {
 	return r.err.Error()
 }
 
-func (r Result[T]) AddErrorDetails(code string, message string) Result[T] {
+func (r Result[T]) AddErrorDetails(code string, message string, capture bool) Result[T] {
 	r.details = &ErrorDetails{
 		Code:    code,
 		Message: message,
+		Capture: capture,
 	}
 	return r
 }


### PR DESCRIPTION
This PR adds some logic to avoid capturing "record not found" error in Sentry when fetching billable metrics and subscriptions from the DB.

This will reduce the noise in Sentry (and slack). The errors will keeps ending up in the dead letter queue