### PR TITLE
misc(processor): Enrich sentry error with event

### DIFF
--- a/events-processor/processors/events.go
+++ b/events-processor/processors/events.go
@@ -51,7 +51,7 @@ func processEvents(records []*kgo.Record) []*kgo.Record {
 				)
 
 				if result.ErrorDetails().Capture {
-					utils.CaptureErrorResult(result)
+					utils.CaptureErrorResultWithExtra(result, "event", event)
 				}
 
 				go produceToDeadLetterQueue(event, result)
@@ -204,6 +204,6 @@ func produceToDeadLetterQueue(event models.Event, errorResult utils.AnyResult) {
 
 	if !pushed {
 		logger.Error("error while pushing to dead letter topic", slog.String("topic", eventsDeadLetterQueue.GetTopic()))
-		utils.CaptureErrorResult(errorResult)
+		utils.CaptureErrorResultWithExtra(errorResult, "event", event)
 	}
 }

--- a/events-processor/utils/error_tracker.go
+++ b/events-processor/utils/error_tracker.go
@@ -3,9 +3,18 @@ package utils
 import "github.com/getsentry/sentry-go"
 
 func CaptureErrorResult(errResult AnyResult) {
+	CaptureErrorResultWithExtra(errResult, "", nil)
+}
+
+func CaptureErrorResultWithExtra(errResult AnyResult, extraKey string, extraValue any) {
 	sentry.WithScope(func(scope *sentry.Scope) {
 		scope.SetExtra("error_code", errResult.ErrorCode())
 		scope.SetExtra("error_message", errResult.ErrorMessage())
+
+		if extraKey != "" {
+			scope.SetExtra(extraKey, extraValue)
+		}
+
 		sentry.CaptureException(errResult.Error())
 	})
 }


### PR DESCRIPTION
To help with debug, this PR improves the error tracking by attaching the event leading to an error as extra data.