### PR TITLE
fix(processor): Avoid committing kafka message in case of transient DB…

### DIFF
--- a/events-processor/config/database/database_test.go
+++ b/events-processor/config/database/database_test.go
@@ -1,10 +1,16 @@
 package database
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"os"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
 )
 
 func TestNewConnection(t *testing.T) {
@@ -23,4 +29,27 @@ func TestNewConnection(t *testing.T) {
 	assert.NotNil(t, db)
 	assert.NotNil(t, db.Connection)
 	assert.NotNil(t, db.logger)
+}
+
+func TestIsTransientError(t *testing.T) {
+	assert.False(t, IsTransientError(nil))
+	assert.False(t, IsTransientError(pgx.ErrNoRows))
+	assert.False(t, IsTransientError(gorm.ErrRecordNotFound))
+
+	assert.True(t, IsTransientError(net.ErrClosed))
+	assert.True(t, IsTransientError(context.DeadlineExceeded))
+	assert.True(t, IsTransientError(context.Canceled))
+
+	connError := &pgconn.PgError{
+		Code:     "40001",
+		Message:  "terminating connection due to conflict with recovery",
+		Severity: "FATAL",
+	}
+	assert.True(t, IsTransientError(connError))
+
+	connError.Code = "42830"
+	connError.Message = "invalid_foreign_key"
+	assert.False(t, IsTransientError(connError))
+
+	assert.True(t, IsTransientError(fmt.Errorf("eof")))
 }

--- a/events-processor/config/kafka/consumer.go
+++ b/events-processor/config/kafka/consumer.go
@@ -63,11 +63,12 @@ func (pc *PartitionConsumer) consume() {
 
 			processedRecords := pc.processRecords(records)
 
-			// Commit the last processed record, to update the commit offset
-			lastRecord := processedRecords[len(processedRecords)-1]
-			err := pc.client.CommitRecords(ctx, lastRecord)
-			if err != nil {
-				pc.logger.Error(fmt.Sprintf("Error when committing offets to kafka. Error: %v topic: %s partition: %d offset: %d\n", err, pc.topic, pc.partition, records[len(records)-1].Offset+1))
+			if len(processedRecords) > 0 {
+				// Commit the last processed records
+				err := pc.client.CommitRecords(ctx, processedRecords...)
+				if err != nil {
+					pc.logger.Error(fmt.Sprintf("Error when committing offets to kafka. Error: %v topic: %s partition: %d offset: %d\n", err, pc.topic, pc.partition, processedRecords[len(processedRecords)-1].Offset+1))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds new logic to avoid committing consumed kafka message when the processing failed because of the temporary database error.
The consumer will keep consuming message starting at the offset of the first uncommitted message