### PR TITLE
misc(processor): Flag errors fore retry and capture and avoid commit

### DIFF
--- a/events-processor/config/kafka/consumer_test.go
+++ b/events-processor/config/kafka/consumer_test.go
@@ -1,0 +1,123 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func createRecord(key string, offset int64) *kgo.Record {
+	return &kgo.Record{
+		Key:    []byte(key),
+		Value:  []byte("value"),
+		Offset: offset,
+	}
+}
+
+func TestFindMaxCommitableRecord(t *testing.T) {
+	{
+		tests := []struct {
+			name             string
+			processedRecords []*kgo.Record
+			records          []*kgo.Record
+			expected         *kgo.Record
+		}{
+			{
+				name: "WIth continuous offsets",
+				processedRecords: []*kgo.Record{
+					createRecord("key1", 1),
+					createRecord("key2", 2),
+				},
+				records: []*kgo.Record{
+					createRecord("key1", 1),
+					createRecord("key2", 2),
+					createRecord("key3", 3),
+					createRecord("key4", 4),
+				},
+				expected: createRecord("key2", 2),
+			},
+			{
+				name: "With non-continuous offsets",
+				processedRecords: []*kgo.Record{
+					createRecord("key1", 1),
+					createRecord("key5", 5),
+				},
+				records: []*kgo.Record{
+					createRecord("key1", 1),
+					createRecord("key3", 3),
+					createRecord("key5", 5),
+					createRecord("key7", 7),
+				},
+				expected: createRecord("key1", 1),
+			},
+			{
+				name:             "With empty processed records",
+				processedRecords: []*kgo.Record{},
+				records: []*kgo.Record{
+					createRecord("key1", 1),
+					createRecord("key3", 3),
+					createRecord("key5", 5),
+					createRecord("key7", 7),
+				},
+				expected: nil,
+			},
+			{
+				name: "All records processed",
+				processedRecords: []*kgo.Record{
+					createRecord("key1", 1),
+					createRecord("key2", 2),
+					createRecord("key3", 3),
+					createRecord("key4", 4),
+				},
+				records: []*kgo.Record{
+					createRecord("key1", 1),
+					createRecord("key2", 2),
+					createRecord("key3", 3),
+					createRecord("key4", 4),
+				},
+				expected: createRecord("key4", 4),
+			},
+			{
+				name: "Only one processed records - not first",
+				processedRecords: []*kgo.Record{
+					createRecord("key5", 5),
+				},
+				records: []*kgo.Record{
+					createRecord("key1", 1),
+					createRecord("key3", 3),
+					createRecord("key5", 5),
+					createRecord("key7", 7),
+				},
+				expected: nil,
+			},
+			{
+				name: "Only one processed records - first",
+				processedRecords: []*kgo.Record{
+					createRecord("key1", 1),
+				},
+				records: []*kgo.Record{
+					createRecord("key1", 1),
+					createRecord("key3", 3),
+					createRecord("key5", 5),
+					createRecord("key7", 7),
+				},
+				expected: createRecord("key1", 1),
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				result := findMaxCommitableRecord(test.processedRecords, test.records)
+
+				if test.expected == nil {
+					assert.Nil(t, result)
+				} else {
+					assert.NotNil(t, result)
+					assert.Equal(t, test.expected.Key, result.Key)
+					assert.Equal(t, test.expected.Offset, result.Offset)
+				}
+			})
+		}
+	}
+}

--- a/events-processor/models/billable_metrics.go
+++ b/events-processor/models/billable_metrics.go
@@ -30,5 +30,11 @@ func (store *ApiStore) FetchBillableMetric(organizationID string, code string) u
 }
 
 func failedBillabmeMetricResult(err error) utils.Result[*BillableMetric] {
-	return utils.FailedResult[*BillableMetric](err)
+	result := utils.FailedResult[*BillableMetric](err)
+
+	if err.Error() == gorm.ErrRecordNotFound.Error() {
+		result = result.NonCapturable().NonRetryable()
+	}
+
+	return result
 }

--- a/events-processor/models/billable_metrics_test.go
+++ b/events-processor/models/billable_metrics_test.go
@@ -75,6 +75,8 @@ func TestFetchBillableMetric(t *testing.T) {
 		assert.NotNil(t, result.Error())
 		assert.Equal(t, gorm.ErrRecordNotFound, result.Error())
 		assert.Nil(t, result.Value())
+		assert.False(t, result.IsCapturable())
+		assert.False(t, result.IsRetryable())
 	})
 
 	t.Run("should handle database connection error", func(t *testing.T) {
@@ -99,5 +101,7 @@ func TestFetchBillableMetric(t *testing.T) {
 		assert.NotNil(t, result.Error())
 		assert.Equal(t, dbError, result.Error())
 		assert.Nil(t, result.Value())
+		assert.True(t, result.IsCapturable())
+		assert.True(t, result.IsRetryable())
 	})
 }

--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -10,16 +10,16 @@ import (
 const HTTP_RUBY string = "http_ruby"
 
 type Event struct {
-	OrganizationID          string          `json:"organization_id"`
-	ExternalSubscriptionID  string          `json:"external_subscription_id"`
-	TransactionID           string          `json:"transaction_id"`
-	Code                    string          `json:"code"`
-	Properties              map[string]any  `json:"properties"`
-	PreciseTotalAmountCents string          `json:"precise_total_amount_cents"`
-	Source                  string          `json:"source,omotempty"`
-	Timestamp               any             `json:"timestamp"`
-	SourceMetadata          *SourceMetadata `json:"source_metadata"`
-	IngestedAt              time.Time       `json:"ingested_at"`
+	OrganizationID          string           `json:"organization_id"`
+	ExternalSubscriptionID  string           `json:"external_subscription_id"`
+	TransactionID           string           `json:"transaction_id"`
+	Code                    string           `json:"code"`
+	Properties              map[string]any   `json:"properties"`
+	PreciseTotalAmountCents string           `json:"precise_total_amount_cents"`
+	Source                  string           `json:"source,omitempty"`
+	Timestamp               any              `json:"timestamp"`
+	SourceMetadata          *SourceMetadata  `json:"source_metadata"`
+	IngestedAt              utils.CustomTime `json:"ingested_at"`
 }
 
 type SourceMetadata struct {
@@ -35,7 +35,7 @@ type EnrichedEvent struct {
 	Code                    string         `json:"code"`
 	Properties              map[string]any `json:"properties"`
 	PreciseTotalAmountCents string         `json:"precise_total_amount_cents"`
-	Source                  string         `json:"source,omotempty"`
+	Source                  string         `json:"source,omitempty"`
 	Value                   *string        `json:"value"`
 	Timestamp               float64        `json:"timestamp"`
 	TimestampStr            string         `json:"-"`

--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -63,14 +63,14 @@ func (ev *Event) ToEnrichedEvent() utils.Result[*EnrichedEvent] {
 
 	timestampResult := utils.ToFloat64Timestamp(ev.Timestamp)
 	if timestampResult.Failure() {
-		return utils.FailedResult[*EnrichedEvent](timestampResult.Error())
+		return utils.FailedResult[*EnrichedEvent](timestampResult.Error()).NonRetryable()
 	}
 	er.Timestamp = timestampResult.Value()
 	er.TimestampStr = fmt.Sprintf("%f", er.Timestamp)
 
 	timeResult := utils.ToTime(ev.Timestamp)
 	if timeResult.Failure() {
-		return utils.FailedResult[*EnrichedEvent](timeResult.Error())
+		return utils.FailedResult[*EnrichedEvent](timeResult.Error()).NonRetryable()
 	}
 	er.Time = timeResult.Value()
 

--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -19,6 +19,7 @@ type Event struct {
 	Source                  string          `json:"source,omotempty"`
 	Timestamp               any             `json:"timestamp"`
 	SourceMetadata          *SourceMetadata `json:"source_metadata"`
+	IngestedAt              time.Time       `json:"ingested_at"`
 }
 
 type SourceMetadata struct {

--- a/events-processor/models/event_test.go
+++ b/events-processor/models/event_test.go
@@ -52,6 +52,7 @@ func TestToEnrichedEvent(t *testing.T) {
 		result := event.ToEnrichedEvent()
 		assert.False(t, result.Success())
 		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-03T13:03:29Z\": invalid syntax", result.ErrorMsg())
+		assert.False(t, result.Retryable)
 	})
 }
 

--- a/events-processor/models/models.go
+++ b/events-processor/models/models.go
@@ -4,8 +4,6 @@ import (
 	"github.com/getlago/lago/events-processor/config/database"
 )
 
-const ERROR_NOT_FOUND string = "record not found"
-
 type ApiStore struct {
 	db *database.DB
 }

--- a/events-processor/models/subscriptions.go
+++ b/events-processor/models/subscriptions.go
@@ -48,5 +48,11 @@ func (store *ApiStore) FetchSubscription(organizationID string, externalID strin
 }
 
 func failedSubscriptionResult(err error) utils.Result[*Subscription] {
-	return utils.FailedResult[*Subscription](err)
+	result := utils.FailedResult[*Subscription](err)
+
+	if err.Error() == gorm.ErrRecordNotFound.Error() {
+		result = result.NonCapturable().NonRetryable()
+	}
+
+	return result
 }

--- a/events-processor/models/subscriptions_test.go
+++ b/events-processor/models/subscriptions_test.go
@@ -78,6 +78,8 @@ func TestFetchSubscription(t *testing.T) {
 		assert.NotNil(t, result.Error())
 		assert.Equal(t, gorm.ErrRecordNotFound, result.Error())
 		assert.Nil(t, result.Value())
+		assert.False(t, result.IsCapturable())
+		assert.False(t, result.IsRetryable())
 	})
 
 	t.Run("should handle database connection error", func(t *testing.T) {
@@ -103,5 +105,7 @@ func TestFetchSubscription(t *testing.T) {
 		assert.NotNil(t, result.Error())
 		assert.Equal(t, dbError, result.Error())
 		assert.Nil(t, result.Value())
+		assert.True(t, result.IsCapturable())
+		assert.True(t, result.IsRetryable())
 	})
 }

--- a/events-processor/processors/events.go
+++ b/events-processor/processors/events.go
@@ -57,7 +57,7 @@ func processEvents(records []*kgo.Record) []*kgo.Record {
 					utils.CaptureErrorResultWithExtra(result, "event", event)
 				}
 
-				if result.IsRetryable() && time.Since(event.IngestedAt) < 12*time.Hour {
+				if result.IsRetryable() && time.Since(event.IngestedAt.Time()) < 12*time.Hour {
 					// For retryable errors, we should avoid commiting the record,
 					// It will be consumed again and reprocessed
 					// Events older than 12 hours should also be pushed dead letter queue

--- a/events-processor/processors/processors.go
+++ b/events-processor/processors/processors.go
@@ -19,7 +19,6 @@ import (
 var (
 	ctx                     context.Context
 	logger                  *slog.Logger
-	err                     error
 	eventsEnrichedProducer  kafka.MessageProducer
 	eventsInAdvanceProducer kafka.MessageProducer
 	eventsDeadLetterQueue   kafka.MessageProducer

--- a/events-processor/utils/result_test.go
+++ b/events-processor/utils/result_test.go
@@ -9,7 +9,9 @@ import (
 
 var successResult = Result[string]{value: "Success", err: nil}
 var failedResult = Result[string]{
-	err: fmt.Errorf("Failed result"),
+	err:       fmt.Errorf("Failed result"),
+	Capture:   true,
+	Retryable: true,
 	details: &ErrorDetails{
 		Code:    "failed_result",
 		Message: "More details",
@@ -117,4 +119,18 @@ func TestResults(t *testing.T) {
 		assert.Equal(t, test.arg.Value(), test.expectedValue)
 		assert.Equal(t, test.arg.ErrorMsg(), test.expectedErrorMsg)
 	}
+}
+
+func TestNonCapturable(t *testing.T) {
+	assert.True(t, failedResult.Capture)
+	assert.True(t, failedResult.IsCapturable())
+	assert.False(t, failedResult.NonCapturable().Capture)
+	assert.False(t, failedResult.NonCapturable().IsCapturable())
+}
+
+func TestNonRetryable(t *testing.T) {
+	assert.True(t, failedResult.Retryable)
+	assert.True(t, failedResult.IsRetryable())
+	assert.False(t, failedResult.NonRetryable().Retryable)
+	assert.False(t, failedResult.NonRetryable().IsRetryable())
 }

--- a/events-processor/utils/time.go
+++ b/events-processor/utils/time.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -61,4 +62,39 @@ func ToFloat64Timestamp(timeValue any) Result[float64] {
 	}
 
 	return SuccessResult(value)
+}
+
+type CustomTime time.Time
+
+func (ct *CustomTime) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), "\"")
+	if s == "null" || s == "" {
+		return nil
+	}
+
+	t, err := time.Parse("2006-01-02T15:04:05", s)
+	if err != nil {
+		return err
+	}
+
+	*ct = CustomTime(t)
+	return nil
+}
+
+func (ct CustomTime) MarshalJSON() ([]byte, error) {
+	t := time.Time(ct)
+	if t.IsZero() {
+		return []byte("null"), nil
+	}
+
+	data := make([]byte, 0, 21) // 19 characters for time format and 2 for quotes
+	return fmt.Appendf(data, "\"%s\"", t.Format("2006-01-02T15:04:05")), nil
+}
+
+func (ct CustomTime) Time() time.Time {
+	return time.Time(ct)
+}
+
+func (ct CustomTime) String() string {
+	return ct.Time().Format("2006-01-02T15:04:05")
 }

--- a/events-processor/utils/time_test.go
+++ b/events-processor/utils/time_test.go
@@ -90,3 +90,28 @@ func TestToFloat64Timestamp(t *testing.T) {
 		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-03T13:03:29Z\": invalid syntax", result.ErrorMsg())
 	})
 }
+
+func TestCustomTime(t *testing.T) {
+	t.Run("With expected time format", func(t *testing.T) {
+		ct := &CustomTime{}
+
+		time := "2025-03-03T13:03:29"
+		err := ct.UnmarshalJSON([]byte(time))
+		assert.NoError(t, err)
+		assert.Equal(t, time, ct.String())
+
+		json, err := ct.MarshalJSON()
+		assert.NoError(t, err)
+
+		data := make([]byte, 0, 21)
+		assert.Equal(t, json, fmt.Appendf(data, "\"%s\"", time))
+	})
+
+	t.Run("With invalid time format", func(t *testing.T) {
+		ct := &CustomTime{}
+
+		time := "2025-03-03T13:03:29Z"
+		err := ct.UnmarshalJSON([]byte(time))
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
# Description

This PR adds new logic to avoid committing consumed kafka message when the processing failed because of a temporary retriable error.
The consumer will keep consuming message starting at the offset of the first uncommitted message.
A safe guard is added to avoid processing message older than 12 hours. The goal is to avoid processing the same events for ever. Old failed message will be sent to the dead letter queue.

The PR also refactors the way we are taking care of capturable errors (the one that we send to Sentry)