### PR TITLE
fix(processor): Handle ingested_at values sent as astring representin…

### DIFF
--- a/events-processor/utils/time.go
+++ b/events-processor/utils/time.go
@@ -74,7 +74,13 @@ func (ct *CustomTime) UnmarshalJSON(b []byte) error {
 
 	t, err := time.Parse("2006-01-02T15:04:05", s)
 	if err != nil {
-		return err
+		// value could be a Unix timestamp encoded as a string
+		timeResult := ToTime(s)
+		if timeResult.Failure() {
+			return err
+		}
+
+		t = timeResult.value
 	}
 
 	*ct = CustomTime(t)

--- a/events-processor/utils/time_test.go
+++ b/events-processor/utils/time_test.go
@@ -114,4 +114,20 @@ func TestCustomTime(t *testing.T) {
 		err := ct.UnmarshalJSON([]byte(time))
 		assert.Error(t, err)
 	})
+
+	t.Run("When timestamp is a unix timestamp sent as string", func(t *testing.T) {
+		ct := &CustomTime{}
+		time := "1744335427"
+		expectedTime := "2025-04-11T01:37:07"
+
+		err := ct.UnmarshalJSON([]byte(time))
+		assert.NoError(t, err)
+		assert.Equal(t, expectedTime, ct.String())
+
+		json, err := ct.MarshalJSON()
+		assert.NoError(t, err)
+
+		data := make([]byte, 0, 21)
+		assert.Equal(t, json, fmt.Appendf(data, "\"%s\"", expectedTime))
+	})
 }


### PR DESCRIPTION
This PR fixes some error related to the unmarshaling of the `ingested_at` value for event when received as a unix timestamp encoded as a string.

The `utils.CustomTime` now support times with the following formats: `"1744335427"` and `"2025-04-11T01:37:07"`