### PR TITLE
misc(readme): remove unnecessary migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,7 @@ cd lago
 echo "LAGO_RSA_PRIVATE_KEY=\"`openssl genrsa 2048 | base64`\"" >> .env
 source .env
 
-# Start the api
-docker compose up -d api
-
-# Create the database
-docker compose exec api rails db:create
-docker compose exec api rails db:migrate
-
-# Start all other components
+# Start all the components
 docker compose up
 ```
 


### PR DESCRIPTION
Following PR #428, `docker-compose` now uses service dependencies to ensure migrations are run before the API container starts. This change removes outdated instructions and simplifies the process.