### PR TITLE
chore(webhook): Add a container to log and debug webhooks in dev environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -315,8 +315,6 @@ services:
     image: ghcr.io/tarampampam/webhook-tester:2
     container_name: lago_webhook_dev
     restart: unless-stopped
-    depends_on:
-      - api
     environment:
       - HTTP_PORT=80
       - AUTO_CREATE_SESSIONS=true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -311,3 +311,18 @@ services:
       - $LAGO_PATH/api:/app:delegated
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@db:5432/${POSTGRES_DB:-lago}
+  webhook:
+    image: ghcr.io/tarampampam/webhook-tester:2
+    container_name: lago_webhook_dev
+    restart: unless-stopped
+    depends_on:
+      - api
+    environment:
+      - HTTP_PORT=80
+      - AUTO_CREATE_SESSIONS=true
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.webhook.rule=Host(`webhook.lago.dev`)"
+      - "traefik.http.routers.webhook.entrypoints=web,ws,websecure"
+      - "traefik.http.routers.webhook.tls=true"
+      - "traefik.http.services.webhook.loadbalancer.server.port=80"


### PR DESCRIPTION
## Description

This PR adds a way to easily test webhooks locally by adding the [`webhook-tester`](https://github.com/tarampampam/webhook-tester) Docker container to the development `docker compose` file.

We'll need to update the API seeds to create a default webhook endpoint: `http://webhook/11111111-2222-3333-4444-555555555555`.

We'll then need to update the [Development Environment wiki](https://github.com/getlago/lago/wiki/Development-Environment) to make sure the `/etc/hosts` include:

```
127.0.0.1 webhook.lago.dev
```

Once that is done, we'll be able to debug the webhooks by accessing: `https://webhook.lago.dev/s/11111111-2222-3333-4444-555555555555`.

Thanks @julienbourdeau for suggesting https://github.com/tarampampam/webhook-tester 😉 