### PR TITLE
feat(pre-aggregation): Enrich events wit aggregation type

### DIFF
--- a/events-processor/models/billable_metrics.go
+++ b/events-processor/models/billable_metrics.go
@@ -8,15 +8,53 @@ import (
 	"github.com/getlago/lago/events-processor/utils"
 )
 
+type AggregationType int
+
+const (
+	AggregationTypeCount = iota
+	AggregationTypeSum
+	AggregationTypeMax
+	AggregationTypeUniqueCount
+	_
+	AggregationTypeWeightedSum
+	AggregationTypeLatest
+	AggregationTypeCustom
+)
+
+func (t AggregationType) String() string {
+	aggType := ""
+
+	switch t {
+	case AggregationTypeCount:
+		aggType = "count"
+	case AggregationTypeSum:
+		aggType = "sum"
+	case AggregationTypeMax:
+		aggType = "max"
+	case AggregationTypeUniqueCount:
+		aggType = "unique_count"
+	case AggregationTypeWeightedSum:
+		aggType = "weighted_sum"
+	case AggregationTypeLatest:
+		aggType = "latest"
+	case AggregationTypeCustom:
+		aggType = "custom"
+	}
+
+	return aggType
+
+}
+
 type BillableMetric struct {
-	ID             string         `gorm:"primaryKey;->"`
-	OrganizationID string         `gorm:"->"`
-	Code           string         `gorm:"->"`
-	FieldName      string         `gorm:"->"`
-	Expression     string         `gorm:"->"`
-	CreatedAt      time.Time      `gorm:"->"`
-	UpdatedAt      time.Time      `gorm:"->"`
-	DeletedAt      gorm.DeletedAt `gorm:"index;->"`
+	ID              string          `gorm:"primaryKey;->"`
+	OrganizationID  string          `gorm:"->"`
+	Code            string          `gorm:"->"`
+	AggregationType AggregationType `gorm:"->"`
+	FieldName       string          `gorm:"->"`
+	Expression      string          `gorm:"->"`
+	CreatedAt       time.Time       `gorm:"->"`
+	UpdatedAt       time.Time       `gorm:"->"`
+	DeletedAt       gorm.DeletedAt  `gorm:"index;->"`
 }
 
 func (store *ApiStore) FetchBillableMetric(organizationID string, code string) utils.Result[*BillableMetric] {

--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -33,6 +33,7 @@ type EnrichedEvent struct {
 	ExternalSubscriptionID  string         `json:"external_subscription_id"`
 	TransactionID           string         `json:"transaction_id"`
 	Code                    string         `json:"code"`
+	AggregationType         string         `json:"aggregation_type"`
 	Properties              map[string]any `json:"properties"`
 	PreciseTotalAmountCents string         `json:"precise_total_amount_cents"`
 	Source                  string         `json:"source,omitempty"`

--- a/events-processor/processors/events.go
+++ b/events-processor/processors/events.go
@@ -99,6 +99,10 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 	}
 	bm := bmResult.Value()
 
+	if bm != nil {
+		enrichedEvent.AggregationType = bm.AggregationType.String()
+	}
+
 	subResult := apiStore.FetchSubscription(event.OrganizationID, event.ExternalSubscriptionID, enrichedEvent.Time)
 	if subResult.Failure() && subResult.IsCapturable() {
 		// We want to keep processing the event even if the subscription is not found

--- a/events-processor/processors/events_test.go
+++ b/events-processor/processors/events_test.go
@@ -32,10 +32,10 @@ func setupTestEnv(t *testing.T) (sqlmock.Sqlmock, func()) {
 }
 
 func mockBmLookup(sqlmock sqlmock.Sqlmock, bm *models.BillableMetric) {
-	columns := []string{"id", "organization_id", "code", "field_name", "expression", "created_at", "updated_at", "deleted_at"}
+	columns := []string{"id", "organization_id", "code", "aggregation_type", "field_name", "expression", "created_at", "updated_at", "deleted_at"}
 
 	rows := sqlmock.NewRows(columns).
-		AddRow(bm.ID, bm.OrganizationID, bm.Code, bm.FieldName, bm.Expression, bm.CreatedAt, bm.UpdatedAt, bm.DeletedAt)
+		AddRow(bm.ID, bm.OrganizationID, bm.Code, bm.AggregationType, bm.FieldName, bm.Expression, bm.CreatedAt, bm.UpdatedAt, bm.DeletedAt)
 
 	sqlmock.ExpectQuery("SELECT \\* FROM \"billable_metrics\".*").WillReturnRows(rows)
 }
@@ -107,13 +107,14 @@ func TestProcessEvent(t *testing.T) {
 		}
 
 		bm := models.BillableMetric{
-			ID:             "bm123",
-			OrganizationID: event.OrganizationID,
-			Code:           event.Code,
-			FieldName:      "api_requests",
-			Expression:     "",
-			CreatedAt:      time.Now(),
-			UpdatedAt:      time.Now(),
+			ID:              "bm123",
+			OrganizationID:  event.OrganizationID,
+			Code:            event.Code,
+			AggregationType: models.AggregationTypeSum,
+			FieldName:       "api_requests",
+			Expression:      "",
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
 		}
 		mockBmLookup(sqlmock, &bm)
 
@@ -127,6 +128,7 @@ func TestProcessEvent(t *testing.T) {
 
 		assert.True(t, result.Success())
 		assert.Equal(t, "12.0", *result.Value().Value)
+		assert.Equal(t, "sum", result.Value().AggregationType)
 
 		// Give some time to the go routine to complete
 		// TODO: Improve this by using channels in the producers methods
@@ -147,13 +149,14 @@ func TestProcessEvent(t *testing.T) {
 		}
 
 		bm := models.BillableMetric{
-			ID:             "bm123",
-			OrganizationID: event.OrganizationID,
-			Code:           event.Code,
-			FieldName:      "api_requests",
-			Expression:     "",
-			CreatedAt:      time.Now(),
-			UpdatedAt:      time.Now(),
+			ID:              "bm123",
+			OrganizationID:  event.OrganizationID,
+			Code:            event.Code,
+			AggregationType: models.AggregationTypeWeightedSum,
+			FieldName:       "api_requests",
+			Expression:      "",
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
 		}
 		mockBmLookup(sqlmock, &bm)
 
@@ -177,13 +180,14 @@ func TestProcessEvent(t *testing.T) {
 		}
 
 		bm := models.BillableMetric{
-			ID:             "bm123",
-			OrganizationID: event.OrganizationID,
-			Code:           event.Code,
-			FieldName:      "api_requests",
-			Expression:     "",
-			CreatedAt:      time.Now(),
-			UpdatedAt:      time.Now(),
+			ID:              "bm123",
+			OrganizationID:  event.OrganizationID,
+			Code:            event.Code,
+			AggregationType: models.AggregationTypeWeightedSum,
+			FieldName:       "api_requests",
+			Expression:      "",
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
 		}
 		mockBmLookup(sqlmock, &bm)
 
@@ -206,13 +210,14 @@ func TestProcessEvent(t *testing.T) {
 		}
 
 		bm := models.BillableMetric{
-			ID:             "bm123",
-			OrganizationID: event.OrganizationID,
-			Code:           event.Code,
-			FieldName:      "api_requests",
-			Expression:     "",
-			CreatedAt:      time.Now(),
-			UpdatedAt:      time.Now(),
+			ID:              "bm123",
+			OrganizationID:  event.OrganizationID,
+			Code:            event.Code,
+			AggregationType: models.AggregationTypeWeightedSum,
+			FieldName:       "api_requests",
+			Expression:      "",
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
 		}
 		mockBmLookup(sqlmock, &bm)
 
@@ -243,13 +248,14 @@ func TestProcessEvent(t *testing.T) {
 		}
 
 		bm := models.BillableMetric{
-			ID:             "bm123",
-			OrganizationID: event.OrganizationID,
-			Code:           event.Code,
-			FieldName:      "api_requests",
-			Expression:     "round(event.properties.value)",
-			CreatedAt:      time.Now(),
-			UpdatedAt:      time.Now(),
+			ID:              "bm123",
+			OrganizationID:  event.OrganizationID,
+			Code:            event.Code,
+			AggregationType: models.AggregationTypeWeightedSum,
+			FieldName:       "api_requests",
+			Expression:      "round(event.properties.value)",
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
 		}
 		mockBmLookup(sqlmock, &bm)
 
@@ -281,13 +287,14 @@ func TestProcessEvent(t *testing.T) {
 		}
 
 		bm := models.BillableMetric{
-			ID:             "bm123",
-			OrganizationID: event.OrganizationID,
-			Code:           event.Code,
-			FieldName:      "api_requests",
-			Expression:     "round(event.properties.value)",
-			CreatedAt:      time.Now(),
-			UpdatedAt:      time.Now(),
+			ID:              "bm123",
+			OrganizationID:  event.OrganizationID,
+			Code:            event.Code,
+			AggregationType: models.AggregationTypeWeightedSum,
+			FieldName:       "api_requests",
+			Expression:      "round(event.properties.value)",
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
 		}
 		mockBmLookup(sqlmock, &bm)
 


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This pull request is adding the `AggregationType` field to the `EnrichedEvent`. It will be used later to apply the Clickhouse aggregation functions.
