### PR TITLE
feat(pre-aggregation):  Enrich event wit SubscriptionID and PlanID

### DIFF
--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -31,6 +31,8 @@ type EnrichedEvent struct {
 
 	OrganizationID          string         `json:"organization_id"`
 	ExternalSubscriptionID  string         `json:"external_subscription_id"`
+	SubscriptionID          string         `json:"subscription_id"`
+	PlanID                  string         `json:"plan_id"`
 	TransactionID           string         `json:"transaction_id"`
 	Code                    string         `json:"code"`
 	AggregationType         string         `json:"aggregation_type"`

--- a/events-processor/processors/events.go
+++ b/events-processor/processors/events.go
@@ -110,6 +110,11 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 	}
 	sub := subResult.Value()
 
+	if sub != nil {
+		enrichedEvent.SubscriptionID = sub.ID
+		enrichedEvent.PlanID = sub.PlanID
+	}
+
 	if event.Source != models.HTTP_RUBY {
 		expressionResult := evaluateExpression(enrichedEvent, bm)
 		if expressionResult.Failure() {

--- a/events-processor/processors/events_test.go
+++ b/events-processor/processors/events_test.go
@@ -118,7 +118,7 @@ func TestProcessEvent(t *testing.T) {
 		}
 		mockBmLookup(sqlmock, &bm)
 
-		sub := models.Subscription{ID: "sub123"}
+		sub := models.Subscription{ID: "sub123", PlanID: "plan123"}
 		mockSubscriptionLookup(sqlmock, &sub)
 
 		enrichedProducer := tests.MockMessageProducer{}
@@ -129,6 +129,8 @@ func TestProcessEvent(t *testing.T) {
 		assert.True(t, result.Success())
 		assert.Equal(t, "12.0", *result.Value().Value)
 		assert.Equal(t, "sum", result.Value().AggregationType)
+		assert.Equal(t, "sub123", result.Value().SubscriptionID)
+		assert.Equal(t, "plan123", result.Value().PlanID)
 
 		// Give some time to the go routine to complete
 		// TODO: Improve this by using channels in the producers methods


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This pull request is adding the `SubscriptionID` and `PlanID` fields to the `EnrichedEvent`. It will be used later to filter the enriched events and pre aggregated results
