### PR TITLE
feat(pre-aggregation): Enrich events with Charge and Filters

### DIFF
--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -30,6 +30,7 @@ type EnrichedEvent struct {
 	IntialEvent    *Event          `json:"-"`
 	BillableMetric *BillableMetric `json:"-"`
 	Subscription   *Subscription   `json:"-"`
+	FlatFilter     *FlatFilter     `json:"-"`
 
 	OrganizationID          string         `json:"organization_id"`
 	ExternalSubscriptionID  string         `json:"external_subscription_id"`
@@ -45,6 +46,10 @@ type EnrichedEvent struct {
 	Timestamp               float64        `json:"timestamp"`
 	TimestampStr            string         `json:"-"`
 	Time                    time.Time      `json:"-"`
+	ChargeID                *string        `json:"charge_id"`
+	ChargeUpdatedAt         *time.Time     `json:"charge_updated_at"`
+	ChargeFilterID          *string        `json:"charge_filter_id"`
+	ChargeFilterUpdatedAt   *time.Time     `json:"charge_filter_updated_at"`
 }
 
 type FailedEvent struct {

--- a/events-processor/processors/event_processors/base_service.go
+++ b/events-processor/processors/event_processors/base_service.go
@@ -11,3 +11,14 @@ func failedResult(r utils.AnyResult, code string, message string) utils.Result[*
 	result.Capture = r.IsCapturable()
 	return result
 }
+
+func failedMultiEventsResult(r utils.AnyResult, code string, message string) utils.Result[[]*models.EnrichedEvent] {
+	result := utils.FailedResult[[]*models.EnrichedEvent](r.Error()).AddErrorDetails(code, message)
+	result.Retryable = r.IsRetryable()
+	result.Capture = r.IsCapturable()
+	return result
+}
+
+func toMultiEventsResult(r utils.Result[*models.EnrichedEvent]) utils.Result[[]*models.EnrichedEvent] {
+	return failedMultiEventsResult(r, r.ErrorCode(), r.ErrorMessage())
+}

--- a/events-processor/processors/event_processors/cache_service.go
+++ b/events-processor/processors/event_processors/cache_service.go
@@ -1,0 +1,29 @@
+package event_processors
+
+import (
+	"github.com/getlago/lago/events-processor/models"
+	"github.com/getlago/lago/events-processor/utils"
+)
+
+type CacheService struct {
+	chargeCacheStore *models.ChargeCache
+}
+
+func NewCacheService(chargeCacheStore *models.ChargeCache) *CacheService {
+	return &CacheService{
+		chargeCacheStore: chargeCacheStore,
+	}
+}
+
+func (s *CacheService) ExpireCache(events []*models.EnrichedEvent) {
+	for _, event := range events {
+		if event.FlatFilter == nil {
+			continue
+		}
+
+		cacheResult := s.chargeCacheStore.Expire(event.FlatFilter, event.SubscriptionID)
+		if cacheResult.Failure() {
+			utils.CaptureError(cacheResult.Error())
+		}
+	}
+}

--- a/events-processor/processors/event_processors/cache_service_test.go
+++ b/events-processor/processors/event_processors/cache_service_test.go
@@ -1,0 +1,191 @@
+package event_processors
+
+import (
+	"testing"
+	"time"
+
+	"github.com/getlago/lago/events-processor/models"
+	"github.com/getlago/lago/events-processor/tests"
+	"github.com/stretchr/testify/assert"
+)
+
+var cacheService *CacheService
+var cacheStore tests.MockCacheStore
+
+func setupCacheServiceEnv() {
+	cacheStore = tests.MockCacheStore{}
+	var chargeCache models.Cacher = &cacheStore
+	chargeCacheStore := models.NewChargeCache(&chargeCache)
+	cacheService = NewCacheService(chargeCacheStore)
+}
+
+func TestExpireCache(t *testing.T) {
+	t.Run("With a single event", func(t *testing.T) {
+		setupCacheServiceEnv()
+
+		now := time.Now()
+		chargeFilterId := "charge_filter_id"
+
+		flatFilter := &models.FlatFilter{
+			OrganizationID:        "org_id",
+			BillableMetricCode:    "api_calls",
+			PlanID:                "plan_id",
+			ChargeID:              "charge_id2",
+			ChargeUpdatedAt:       now,
+			ChargeFilterID:        &chargeFilterId,
+			ChargeFilterUpdatedAt: &now,
+			Filters:               &models.FlatFilterValues{"scheme": []string{"visa"}},
+		}
+
+		event := models.EnrichedEvent{
+			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			ExternalSubscriptionID: "sub_id",
+			Code:                   "api_calls",
+			Properties:             map[string]any{"scheme": "visa"},
+			SubscriptionID:         "sub123",
+			FlatFilter:             flatFilter,
+		}
+
+		cacheService.ExpireCache([]*models.EnrichedEvent{&event})
+
+		assert.Equal(t, 1, cacheStore.ExecutionCount)
+	})
+
+	t.Run("With a single event and no flat filter", func(t *testing.T) {
+		setupCacheServiceEnv()
+
+		event := models.EnrichedEvent{
+			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			ExternalSubscriptionID: "sub_id",
+			Code:                   "api_calls",
+			Properties:             map[string]any{"scheme": "visa"},
+			SubscriptionID:         "sub123",
+		}
+
+		cacheService.ExpireCache([]*models.EnrichedEvent{&event})
+
+		assert.Equal(t, 0, cacheStore.ExecutionCount)
+	})
+
+	t.Run("With a single event and no flat filter and no charge filter", func(t *testing.T) {
+		setupCacheServiceEnv()
+
+		now := time.Now()
+		chargeFilterId := "charge_filter_id"
+
+		flatFilter := &models.FlatFilter{
+			OrganizationID:        "org_id",
+			BillableMetricCode:    "api_calls",
+			PlanID:                "plan_id",
+			ChargeID:              "charge_id2",
+			ChargeUpdatedAt:       now,
+			ChargeFilterID:        &chargeFilterId,
+			ChargeFilterUpdatedAt: &now,
+			Filters:               &models.FlatFilterValues{"scheme": []string{"visa"}},
+		}
+
+		event := models.EnrichedEvent{
+			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			ExternalSubscriptionID: "sub_id",
+			Code:                   "api_calls",
+			Properties:             map[string]any{"scheme": "visa"},
+			SubscriptionID:         "sub123",
+			FlatFilter:             flatFilter,
+		}
+
+		cacheService.ExpireCache([]*models.EnrichedEvent{&event})
+
+		assert.Equal(t, 1, cacheStore.ExecutionCount)
+	})
+
+	t.Run("With multiple events", func(t *testing.T) {
+		setupCacheServiceEnv()
+
+		now := time.Now()
+		chargeFilterId1 := "charge_filter_id1"
+		chargeFilterId2 := "charge_filter_id2"
+
+		flatFilter1 := &models.FlatFilter{
+			OrganizationID:        "org_id",
+			BillableMetricCode:    "api_calls",
+			PlanID:                "plan_id",
+			ChargeID:              "charge_id2",
+			ChargeUpdatedAt:       now,
+			ChargeFilterID:        &chargeFilterId1,
+			ChargeFilterUpdatedAt: &now,
+			Filters:               &models.FlatFilterValues{"scheme": []string{"visa"}},
+		}
+
+		flatFilter2 := &models.FlatFilter{
+			OrganizationID:        "org_id",
+			BillableMetricCode:    "api_calls",
+			PlanID:                "plan_id",
+			ChargeID:              "charge_id2",
+			ChargeUpdatedAt:       now,
+			ChargeFilterID:        &chargeFilterId2,
+			ChargeFilterUpdatedAt: &now,
+			Filters:               &models.FlatFilterValues{"scheme": []string{"visa"}},
+		}
+
+		event1 := models.EnrichedEvent{
+			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			ExternalSubscriptionID: "sub_id",
+			Code:                   "api_calls",
+			Properties:             map[string]any{"scheme": "visa"},
+			SubscriptionID:         "sub123",
+			FlatFilter:             flatFilter1,
+		}
+
+		event2 := models.EnrichedEvent{
+			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			ExternalSubscriptionID: "sub_id",
+			Code:                   "api_calls",
+			Properties:             map[string]any{"scheme": "visa"},
+			SubscriptionID:         "sub123",
+			FlatFilter:             flatFilter2,
+		}
+
+		cacheService.ExpireCache([]*models.EnrichedEvent{&event1, &event2})
+
+		assert.Equal(t, 2, cacheStore.ExecutionCount)
+	})
+
+	t.Run("With multiple events and a missing filter", func(t *testing.T) {
+		setupCacheServiceEnv()
+
+		now := time.Now()
+		chargeFilterId := "charge_filter_id"
+
+		flatFilter := &models.FlatFilter{
+			OrganizationID:        "org_id",
+			BillableMetricCode:    "api_calls",
+			PlanID:                "plan_id",
+			ChargeID:              "charge_id2",
+			ChargeUpdatedAt:       now,
+			ChargeFilterID:        &chargeFilterId,
+			ChargeFilterUpdatedAt: &now,
+			Filters:               &models.FlatFilterValues{"scheme": []string{"visa"}},
+		}
+
+		event1 := models.EnrichedEvent{
+			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			ExternalSubscriptionID: "sub_id",
+			Code:                   "api_calls",
+			Properties:             map[string]any{"scheme": "visa"},
+			SubscriptionID:         "sub123",
+			FlatFilter:             flatFilter,
+		}
+
+		event2 := models.EnrichedEvent{
+			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			ExternalSubscriptionID: "sub_id",
+			Code:                   "api_calls",
+			Properties:             map[string]any{"scheme": "visa"},
+			SubscriptionID:         "sub123",
+		}
+
+		cacheService.ExpireCache([]*models.EnrichedEvent{&event1, &event2})
+
+		assert.Equal(t, 1, cacheStore.ExecutionCount)
+	})
+}


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This pull request add the new logic to enrich events with charge and charge filters details. The logic to load the charges that was used in the cache management has been moved in the enrichment phase and is reused in the new cache service to avoid re-loading the same data multiple time.

NOTE: For now, the event is enriched with filters only when it is not post-processed on the API, it will be enabled for all events when the clickhouse pipeline will be ready