### PR TITLE
feat(pre-aggregation): Enrich events with grouped by

### DIFF
--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -32,24 +32,25 @@ type EnrichedEvent struct {
 	Subscription   *Subscription   `json:"-"`
 	FlatFilter     *FlatFilter     `json:"-"`
 
-	OrganizationID          string         `json:"organization_id"`
-	ExternalSubscriptionID  string         `json:"external_subscription_id"`
-	SubscriptionID          string         `json:"subscription_id"`
-	PlanID                  string         `json:"plan_id"`
-	TransactionID           string         `json:"transaction_id"`
-	Code                    string         `json:"code"`
-	AggregationType         string         `json:"aggregation_type"`
-	Properties              map[string]any `json:"properties"`
-	PreciseTotalAmountCents string         `json:"precise_total_amount_cents"`
-	Source                  string         `json:"source,omitempty"`
-	Value                   *string        `json:"value"`
-	Timestamp               float64        `json:"timestamp"`
-	TimestampStr            string         `json:"-"`
-	Time                    time.Time      `json:"-"`
-	ChargeID                *string        `json:"charge_id"`
-	ChargeUpdatedAt         *time.Time     `json:"charge_updated_at"`
-	ChargeFilterID          *string        `json:"charge_filter_id"`
-	ChargeFilterUpdatedAt   *time.Time     `json:"charge_filter_updated_at"`
+	OrganizationID          string            `json:"organization_id"`
+	ExternalSubscriptionID  string            `json:"external_subscription_id"`
+	SubscriptionID          string            `json:"subscription_id"`
+	PlanID                  string            `json:"plan_id"`
+	TransactionID           string            `json:"transaction_id"`
+	Code                    string            `json:"code"`
+	AggregationType         string            `json:"aggregation_type"`
+	Properties              map[string]any    `json:"properties"`
+	PreciseTotalAmountCents string            `json:"precise_total_amount_cents"`
+	Source                  string            `json:"source,omitempty"`
+	Value                   *string           `json:"value"`
+	Timestamp               float64           `json:"timestamp"`
+	TimestampStr            string            `json:"-"`
+	Time                    time.Time         `json:"-"`
+	ChargeID                *string           `json:"charge_id"`
+	ChargeUpdatedAt         *time.Time        `json:"charge_updated_at"`
+	ChargeFilterID          *string           `json:"charge_filter_id"`
+	ChargeFilterUpdatedAt   *time.Time        `json:"charge_filter_updated_at"`
+	GroupedBy               map[string]string `json:"grouped_by"`
 }
 
 type FailedEvent struct {

--- a/events-processor/models/flat_filters.go
+++ b/events-processor/models/flat_filters.go
@@ -11,6 +11,7 @@ import (
 )
 
 type FlatFilterValues map[string][]string
+type PricingGroupKeys []string
 
 // Implements the sql.Scanner interface to convert JSONB into FlatFilterValues
 func (fm *FlatFilterValues) Scan(value any) error {
@@ -47,6 +48,41 @@ func (fm FlatFilterValues) Value() (driver.Value, error) {
 	return json.Marshal(map[string][]string(fm))
 }
 
+// Implements the sql.Scanner interface to convert JSONB into FlatFilterValues
+func (fm *PricingGroupKeys) Scan(value any) error {
+	if value == nil {
+		*fm = nil
+		return nil
+	}
+
+	var bytes []byte
+	switch v := value.(type) {
+	case []byte:
+		bytes = v
+	case string:
+		bytes = []byte(v)
+	default:
+		return fmt.Errorf("cannot scan %T into FlatFilterValues", value)
+	}
+
+	var result []string
+	if err := json.Unmarshal(bytes, &result); err != nil {
+		return err
+	}
+
+	*fm = PricingGroupKeys(result)
+	return nil
+}
+
+// Implements the driver.Valuer interface converting FlatFilterValues to a JSONB value
+func (fm PricingGroupKeys) Value() (driver.Value, error) {
+	if fm == nil {
+		return nil, nil
+	}
+
+	return json.Marshal([]string(fm))
+}
+
 type FlatFilter struct {
 	OrganizationID        string            `gorm:"->"`
 	BillableMetricCode    string            `gorm:"->"`
@@ -56,6 +92,8 @@ type FlatFilter struct {
 	ChargeFilterID        *string           `gorm:"->"`
 	ChargeFilterUpdatedAt *time.Time        `gorm:"->"`
 	Filters               *FlatFilterValues `gorm:"type:jsonb"`
+	Properties            map[string]any    `gorm:"type:jsonb"`
+	PricingGroupKeys      PricingGroupKeys  `gorm:"type:jsonb"`
 }
 
 func (store *ApiStore) FetchFlatFilters(planID string, billableMetricCode string) utils.Result[[]FlatFilter] {

--- a/events-processor/models/flat_filters_test.go
+++ b/events-processor/models/flat_filters_test.go
@@ -31,10 +31,13 @@ func TestFetchFlatFilters(t *testing.T) {
 		// Convert filters to JSON for JSONB column
 		filtersJSON, _ := json.Marshal(filters)
 
+		pricingGroupKeys := []string{"country", "region"}
+		pricingGroupKeysJSON, _ := json.Marshal(pricingGroupKeys)
+
 		// Define expected rows and columns
-		columns := []string{"organization_id", "billable_metric_code", "plan_id", "charge_id", "charge_updated_at", "charge_filter_id", "charge_filter_updated_at", "filters"}
+		columns := []string{"organization_id", "billable_metric_code", "plan_id", "charge_id", "charge_updated_at", "charge_filter_id", "charge_filter_updated_at", "filters", "pricing_group_keys"}
 		rows := sqlmock.NewRows(columns).
-			AddRow("1a901a90-1a90-1a90-1a90-1a901a901a90", code, planID, "1a901a90-1a90-1a90-1a90-1a901a901a90", now, "1a901a90-1a90-1a90-1a90-1a901a901a90", now, filtersJSON)
+			AddRow("1a901a90-1a90-1a90-1a90-1a901a901a90", code, planID, "1a901a90-1a90-1a90-1a90-1a901a901a90", now, "1a901a90-1a90-1a90-1a90-1a901a901a90", now, filtersJSON, pricingGroupKeysJSON)
 
 		// Expect the query
 		mock.ExpectQuery(fetchFiltersQuery).
@@ -53,6 +56,8 @@ func TestFetchFlatFilters(t *testing.T) {
 		// Convert FilterMap back to regular map for comparison
 		actualFilters := map[string][]string(*flatFilter.Filters)
 		assert.Equal(t, filters, actualFilters)
+
+		assert.Equal(t, pricingGroupKeys, []string(flatFilter.PricingGroupKeys))
 	})
 
 	t.Run("should return an empty result when not found", func(t *testing.T) {

--- a/events-processor/processors/event_processors/enrichment_service.go
+++ b/events-processor/processors/event_processors/enrichment_service.go
@@ -145,8 +145,22 @@ func (s *EventEnrichmentService) enrichWithChargeInfo(enrichedEvent *models.Enri
 		enrichedEventCopy.ChargeUpdatedAt = &matchingFilter.ChargeUpdatedAt
 		enrichedEventCopy.ChargeFilterID = matchingFilter.ChargeFilterID
 		enrichedEventCopy.ChargeFilterUpdatedAt = matchingFilter.ChargeFilterUpdatedAt
+
+		enrichWithPricingGroupKeys(&enrichedEventCopy)
+
 		enrichedEvents = append(enrichedEvents, &enrichedEventCopy)
 	}
 
 	return utils.SuccessResult(enrichedEvents)
+}
+
+func enrichWithPricingGroupKeys(event *models.EnrichedEvent) {
+	if event.FlatFilter == nil || event.FlatFilter.PricingGroupKeys == nil {
+		return
+	}
+
+	event.GroupedBy = make(map[string]string)
+	for _, key := range event.FlatFilter.PricingGroupKeys {
+		event.GroupedBy[key] = fmt.Sprintf("%v", event.Properties[key])
+	}
 }


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This pull request add the new logic to enrich events with the pricing group keys.

NOTE: For now, the event is enriched with grouped by only when it is not post-processed on the API, it will be enabled for all events when the Clickhouse pipeline will be ready