### PR TITLE
misc(pre-aggregation): Refactor kafka producers

### DIFF
--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -27,7 +27,7 @@ type SourceMetadata struct {
 }
 
 type EnrichedEvent struct {
-	IntialEvent    *Event          `json:"-"`
+	InitialEvent   *Event          `json:"-"`
 	BillableMetric *BillableMetric `json:"-"`
 	Subscription   *Subscription   `json:"-"`
 	FlatFilter     *FlatFilter     `json:"-"`
@@ -63,7 +63,7 @@ type FailedEvent struct {
 
 func (ev *Event) ToEnrichedEvent() utils.Result[*EnrichedEvent] {
 	er := &EnrichedEvent{
-		IntialEvent:             ev,
+		InitialEvent:            ev,
 		OrganizationID:          ev.OrganizationID,
 		ExternalSubscriptionID:  ev.ExternalSubscriptionID,
 		TransactionID:           ev.TransactionID,

--- a/events-processor/processors/event_processors/base_service.go
+++ b/events-processor/processors/event_processors/base_service.go
@@ -5,6 +5,20 @@ import (
 	"github.com/getlago/lago/events-processor/utils"
 )
 
+type EventProcessor struct {
+	EnrichmentService *EventEnrichmentService
+	ProducerService   *EventProducerService
+	CacheService      *CacheService
+}
+
+func NewEventProcessor(enrichmentService *EventEnrichmentService, producerService *EventProducerService, cacheService *CacheService) *EventProcessor {
+	return &EventProcessor{
+		EnrichmentService: enrichmentService,
+		ProducerService:   producerService,
+		CacheService:      cacheService,
+	}
+}
+
 func failedResult(r utils.AnyResult, code string, message string) utils.Result[*models.EnrichedEvent] {
 	result := utils.FailedResult[*models.EnrichedEvent](r.Error()).AddErrorDetails(code, message)
 	result.Retryable = r.IsRetryable()

--- a/events-processor/processors/event_processors/enrichment_service.go
+++ b/events-processor/processors/event_processors/enrichment_service.go
@@ -107,7 +107,7 @@ func (s *EventEnrichmentService) enrichWithSubscription(enrichedEvent *models.En
 
 func (s *EventEnrichmentService) enrichWithChargeInfo(enrichedEvent *models.EnrichedEvent) utils.Result[[]*models.EnrichedEvent] {
 	// TODO(pre-aggregation): Remove the NotAPIPostProcessed condition to enable pre-aggregation
-	if !enrichedEvent.IntialEvent.NotAPIPostProcessed() || enrichedEvent.Subscription == nil {
+	if !enrichedEvent.InitialEvent.NotAPIPostProcessed() || enrichedEvent.Subscription == nil {
 		return utils.SuccessResult([]*models.EnrichedEvent{enrichedEvent})
 	}
 

--- a/events-processor/processors/event_processors/event_producer_service.go
+++ b/events-processor/processors/event_processors/event_producer_service.go
@@ -1,0 +1,91 @@
+package event_processors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/getlago/lago/events-processor/config/kafka"
+	"github.com/getlago/lago/events-processor/models"
+	"github.com/getlago/lago/events-processor/utils"
+)
+
+type EventProducerService struct {
+	enrichedProducer   kafka.MessageProducer
+	inAdvanceProducer  kafka.MessageProducer
+	deadLetterProducer kafka.MessageProducer
+	logger             *slog.Logger
+}
+
+func NewEventProducerService(enrichedProducer, inAdvanceProducer, deadLetterProducer kafka.MessageProducer, logger *slog.Logger) *EventProducerService {
+	return &EventProducerService{
+		enrichedProducer:   enrichedProducer,
+		inAdvanceProducer:  inAdvanceProducer,
+		deadLetterProducer: deadLetterProducer,
+		logger:             logger,
+	}
+}
+
+func (eps *EventProducerService) ProduceEnrichedEvent(context context.Context, event *models.EnrichedEvent) {
+	eventJson, err := json.Marshal(event)
+	if err != nil {
+		eps.logger.Error("error while marshaling enriched events")
+	}
+
+	msgKey := fmt.Sprintf("%s-%s-%s", event.OrganizationID, event.ExternalSubscriptionID, event.Code)
+
+	pushed := eps.enrichedProducer.Produce(context, &kafka.ProducerMessage{
+		Key:   []byte(msgKey),
+		Value: eventJson,
+	})
+
+	if !pushed {
+		eps.ProduceToDeadLetterQueue(context, *event.InitialEvent, utils.FailedBoolResult(fmt.Errorf("Failed to push to %s topic", eps.enrichedProducer.GetTopic())))
+	}
+}
+
+func (eps *EventProducerService) ProduceChargedInAdvanceEvent(context context.Context, event *models.EnrichedEvent) {
+	eventJson, err := json.Marshal(event)
+	if err != nil {
+		eps.logger.Error("error while marshaling charged in advance events")
+		utils.CaptureError(err)
+	}
+
+	msgKey := fmt.Sprintf("%s-%s-%s", event.OrganizationID, event.ExternalSubscriptionID, event.Code)
+
+	pushed := eps.inAdvanceProducer.Produce(context, &kafka.ProducerMessage{
+		Key:   []byte(msgKey),
+		Value: eventJson,
+	})
+
+	if !pushed {
+		eps.ProduceToDeadLetterQueue(context, *event.InitialEvent, utils.FailedBoolResult(fmt.Errorf("Failed to push to %s topic", eps.inAdvanceProducer.GetTopic())))
+	}
+}
+
+func (eps *EventProducerService) ProduceToDeadLetterQueue(context context.Context, event models.Event, errorResult utils.AnyResult) {
+	failedEvent := models.FailedEvent{
+		Event:               event,
+		InitialErrorMessage: errorResult.ErrorMsg(),
+		ErrorCode:           errorResult.ErrorCode(),
+		ErrorMessage:        errorResult.ErrorMessage(),
+		FailedAt:            time.Now(),
+	}
+
+	eventJson, err := json.Marshal(failedEvent)
+	if err != nil {
+		eps.logger.Error("error while marshaling failed event with error details")
+		utils.CaptureError(err)
+	}
+
+	pushed := eps.deadLetterProducer.Produce(context, &kafka.ProducerMessage{
+		Value: eventJson,
+	})
+
+	if !pushed {
+		eps.logger.Error("error while pushing to dead letter topic", slog.String("topic", eps.deadLetterProducer.GetTopic()))
+		utils.CaptureErrorResultWithExtra(errorResult, "event", event)
+	}
+}

--- a/events-processor/processors/event_processors/event_producer_service_test.go
+++ b/events-processor/processors/event_processors/event_producer_service_test.go
@@ -1,0 +1,104 @@
+package event_processors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/getlago/lago/events-processor/models"
+	"github.com/getlago/lago/events-processor/tests"
+	"github.com/getlago/lago/events-processor/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	producerService    *EventProducerService
+	enrichedProducer   *tests.MockMessageProducer
+	inAdvanceProducer  *tests.MockMessageProducer
+	deadLetterProducer *tests.MockMessageProducer
+	logger             *slog.Logger
+)
+
+func setupProducerServiceEnv() {
+	enrichedProducer = &tests.MockMessageProducer{}
+	inAdvanceProducer = &tests.MockMessageProducer{}
+	deadLetterProducer = &tests.MockMessageProducer{}
+
+	logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
+	producerService = NewEventProducerService(enrichedProducer, inAdvanceProducer, deadLetterProducer, logger)
+}
+
+func TestProduceEnrichedEvent(t *testing.T) {
+	setupProducerServiceEnv()
+
+	event := models.EnrichedEvent{
+		OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+		ExternalSubscriptionID: "sub_id",
+		Code:                   "api_calls",
+	}
+
+	producerService.ProduceEnrichedEvent(context.Background(), &event)
+
+	assert.Equal(t, 1, enrichedProducer.ExecutionCount)
+	assert.Equal(
+		t,
+		[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-sub_id-api_calls"),
+		enrichedProducer.Key,
+	)
+
+	eventJson, _ := json.Marshal(event)
+	assert.Equal(t, eventJson, enrichedProducer.Value)
+}
+
+func TestProduceChargedInAdvanceEvent(t *testing.T) {
+	setupProducerServiceEnv()
+
+	event := models.EnrichedEvent{
+		OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+		ExternalSubscriptionID: "sub_id",
+		Code:                   "api_calls",
+	}
+
+	producerService.ProduceChargedInAdvanceEvent(context.Background(), &event)
+
+	assert.Equal(t, 1, inAdvanceProducer.ExecutionCount)
+	assert.Equal(
+		t,
+		[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-sub_id-api_calls"),
+		inAdvanceProducer.Key,
+	)
+
+	eventJson, _ := json.Marshal(event)
+	assert.Equal(t, eventJson, inAdvanceProducer.Value)
+}
+
+func TestProduceToDeadLetterQueue(t *testing.T) {
+	setupProducerServiceEnv()
+
+	event := models.Event{
+		OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+		ExternalSubscriptionID: "sub_id",
+		Code:                   "api_calls",
+	}
+
+	result := utils.FailedResult[string](fmt.Errorf("Error Message"))
+	producerService.ProduceToDeadLetterQueue(context.Background(), event, result)
+
+	var producedEvent models.FailedEvent
+	err := json.Unmarshal(deadLetterProducer.Value, &producedEvent)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, deadLetterProducer.ExecutionCount)
+
+	assert.Equal(t, event, producedEvent.Event)
+	assert.Equal(t, "Error Message", producedEvent.InitialErrorMessage)
+	assert.Equal(t, "", producedEvent.ErrorCode)
+	assert.Equal(t, "", producedEvent.ErrorMessage)
+	assert.WithinDuration(t, time.Now(), producedEvent.FailedAt, 5*time.Second)
+}

--- a/events-processor/processors/events.go
+++ b/events-processor/processors/events.go
@@ -12,9 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	tracer "github.com/getlago/lago/events-processor/config"
-	"github.com/getlago/lago/events-processor/config/kafka"
 	"github.com/getlago/lago/events-processor/models"
-	events "github.com/getlago/lago/events-processor/processors/event_processors"
 	"github.com/getlago/lago/events-processor/utils"
 )
 
@@ -71,7 +69,7 @@ func processEvents(records []*kgo.Record) []*kgo.Record {
 				}
 
 				// Push failed records to the dead letter queue
-				go produceToDeadLetterQueue(event, result)
+				go processor.ProducerService.ProduceToDeadLetterQueue(ctx, event, result)
 			}
 
 			// Track processed records
@@ -87,8 +85,7 @@ func processEvents(records []*kgo.Record) []*kgo.Record {
 }
 
 func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
-	eventEnrichmentService := events.NewEventEnrichmentService(apiStore)
-	enrichedEventResult := eventEnrichmentService.EnrichEvent(event)
+	enrichedEventResult := processor.EnrichmentService.EnrichEvent(event)
 	if enrichedEventResult.Failure() {
 		return failedResult(enrichedEventResult, enrichedEventResult.ErrorCode(), enrichedEventResult.ErrorMessage())
 	}
@@ -96,7 +93,7 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 	enrichedEvents := enrichedEventResult.Value()
 	enrichedEvent := enrichedEvents[0] // TODO:Add full support for multiple enriched events
 
-	go produceEnrichedEvent(enrichedEvent)
+	go processor.ProducerService.ProduceEnrichedEvent(ctx, enrichedEvent)
 
 	if enrichedEvent.Subscription != nil && event.NotAPIPostProcessed() {
 		hasInAdvanceChargeResult := apiStore.AnyInAdvanceCharge(enrichedEvent.PlanID, enrichedEvent.BillableMetric.ID)
@@ -105,7 +102,7 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 		}
 
 		if hasInAdvanceChargeResult.Value() {
-			go produceChargedInAdvanceEvent(enrichedEvent)
+			go processor.ProducerService.ProduceChargedInAdvanceEvent(ctx, enrichedEvent)
 		}
 
 		flagResult := flagSubscriptionRefresh(event.OrganizationID, enrichedEvent.Subscription)
@@ -114,8 +111,7 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 		}
 
 		// Expire cache at charge and charge filter level
-		cacheService := events.NewCacheService(chargeCacheStore)
-		cacheService.ExpireCache(enrichedEvents)
+		processor.CacheService.ExpireCache(enrichedEvents)
 	}
 
 	return utils.SuccessResult(enrichedEvent)
@@ -126,68 +122,6 @@ func failedResult(r utils.AnyResult, code string, message string) utils.Result[*
 	result.Retryable = r.IsRetryable()
 	result.Capture = r.IsCapturable()
 	return result
-}
-
-func produceEnrichedEvent(ev *models.EnrichedEvent) {
-	eventJson, err := json.Marshal(ev)
-	if err != nil {
-		logger.Error("error while marshaling enriched events")
-	}
-
-	msgKey := fmt.Sprintf("%s-%s-%s", ev.OrganizationID, ev.ExternalSubscriptionID, ev.Code)
-
-	pushed := eventsEnrichedProducer.Produce(ctx, &kafka.ProducerMessage{
-		Key:   []byte(msgKey),
-		Value: eventJson,
-	})
-
-	if !pushed {
-		produceToDeadLetterQueue(*ev.IntialEvent, utils.FailedBoolResult(fmt.Errorf("Failed to push to %s topic", eventsEnrichedProducer.GetTopic())))
-	}
-}
-
-func produceChargedInAdvanceEvent(ev *models.EnrichedEvent) {
-	eventJson, err := json.Marshal(ev)
-	if err != nil {
-		logger.Error("error while marshaling charged in advance events")
-		utils.CaptureError(err)
-	}
-
-	msgKey := fmt.Sprintf("%s-%s-%s", ev.OrganizationID, ev.ExternalSubscriptionID, ev.Code)
-
-	pushed := eventsInAdvanceProducer.Produce(ctx, &kafka.ProducerMessage{
-		Key:   []byte(msgKey),
-		Value: eventJson,
-	})
-
-	if !pushed {
-		produceToDeadLetterQueue(*ev.IntialEvent, utils.FailedBoolResult(fmt.Errorf("Failed to push to %s topic", eventsInAdvanceProducer.GetTopic())))
-	}
-}
-
-func produceToDeadLetterQueue(event models.Event, errorResult utils.AnyResult) {
-	failedEvent := models.FailedEvent{
-		Event:               event,
-		InitialErrorMessage: errorResult.ErrorMsg(),
-		ErrorCode:           errorResult.ErrorCode(),
-		ErrorMessage:        errorResult.ErrorMessage(),
-		FailedAt:            time.Now(),
-	}
-
-	eventJson, err := json.Marshal(failedEvent)
-	if err != nil {
-		logger.Error("error while marshaling failed event with error details")
-		utils.CaptureError(err)
-	}
-
-	pushed := eventsDeadLetterQueue.Produce(ctx, &kafka.ProducerMessage{
-		Value: eventJson,
-	})
-
-	if !pushed {
-		logger.Error("error while pushing to dead letter topic", slog.String("topic", eventsDeadLetterQueue.GetTopic()))
-		utils.CaptureErrorResultWithExtra(errorResult, "event", event)
-	}
 }
 
 func flagSubscriptionRefresh(orgID string, sub *models.Subscription) utils.Result[bool] {

--- a/events-processor/tests/mocked_producer.go
+++ b/events-processor/tests/mocked_producer.go
@@ -16,6 +16,7 @@ func (mp *MockMessageProducer) Produce(ctx context.Context, msg *kafka.ProducerM
 	mp.Key = msg.Key
 	mp.Value = msg.Value
 	mp.ExecutionCount++
+
 	return true
 }
 


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This pull extract the event kafka production logic from the events processor into a new dedicated `EventProducerService` sub-service.
It clearly separates the production logic from the event enrichment and the cache expiration. It make the code easier to maintain and test.

It follows previous refactor of the event enrichement and the cache management