### PR TITLE
misc(pre-aggregation): Refactor subscription refresh

### DIFF
--- a/events-processor/processors/event_processors/base_service.go
+++ b/events-processor/processors/event_processors/base_service.go
@@ -8,13 +8,15 @@ import (
 type EventProcessor struct {
 	EnrichmentService *EventEnrichmentService
 	ProducerService   *EventProducerService
+	RefreshService    *SubscriptionRefreshService
 	CacheService      *CacheService
 }
 
-func NewEventProcessor(enrichmentService *EventEnrichmentService, producerService *EventProducerService, cacheService *CacheService) *EventProcessor {
+func NewEventProcessor(enrichmentService *EventEnrichmentService, producerService *EventProducerService, refreshService *SubscriptionRefreshService, cacheService *CacheService) *EventProcessor {
 	return &EventProcessor{
 		EnrichmentService: enrichmentService,
 		ProducerService:   producerService,
+		RefreshService:    refreshService,
 		CacheService:      cacheService,
 	}
 }

--- a/events-processor/processors/event_processors/subscription_refresh_service.go
+++ b/events-processor/processors/event_processors/subscription_refresh_service.go
@@ -1,0 +1,27 @@
+package event_processors
+
+import (
+	"fmt"
+
+	"github.com/getlago/lago/events-processor/models"
+	"github.com/getlago/lago/events-processor/utils"
+)
+
+type SubscriptionRefreshService struct {
+	flagStore models.Flagger
+}
+
+func NewSubscriptionRefreshService(flagStore models.Flagger) *SubscriptionRefreshService {
+	return &SubscriptionRefreshService{
+		flagStore: flagStore,
+	}
+}
+
+func (s *SubscriptionRefreshService) FlagSubscriptionRefresh(event *models.EnrichedEvent) utils.Result[bool] {
+	err := s.flagStore.Flag(fmt.Sprintf("%s:%s", event.OrganizationID, event.SubscriptionID))
+	if err != nil {
+		return utils.FailedBoolResult(err)
+	}
+
+	return utils.SuccessResult(true)
+}

--- a/events-processor/processors/event_processors/subscription_refresh_service_test.go
+++ b/events-processor/processors/event_processors/subscription_refresh_service_test.go
@@ -1,0 +1,41 @@
+package event_processors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/getlago/lago/events-processor/models"
+	"github.com/getlago/lago/events-processor/tests"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	refreshService *SubscriptionRefreshService
+	flagStore      *tests.MockFlagStore
+)
+
+func setupRefreshServiceEnv() {
+	flagStore = &tests.MockFlagStore{}
+
+	refreshService = NewSubscriptionRefreshService(flagStore)
+}
+
+func TestFlagSubscriptionRefresh(t *testing.T) {
+	setupRefreshServiceEnv()
+
+	event := models.EnrichedEvent{
+		OrganizationID: "1a901a90-1a90-1a90-1a90-1a901a901a90",
+		SubscriptionID: "sub_id",
+	}
+
+	result := refreshService.FlagSubscriptionRefresh(&event)
+	assert.Equal(t, 1, flagStore.ExecutionCount)
+	assert.True(t, result.Success())
+	assert.True(t, result.Value())
+
+	flagStore.ReturnedError = fmt.Errorf("Failed to flag subscription")
+	result = refreshService.FlagSubscriptionRefresh(&event)
+	assert.Equal(t, 2, flagStore.ExecutionCount)
+	assert.True(t, result.Failure())
+	assert.Error(t, result.Error())
+}

--- a/events-processor/processors/processors.go
+++ b/events-processor/processors/processors.go
@@ -18,13 +18,12 @@ import (
 )
 
 var (
-	ctx                   context.Context
-	logger                *slog.Logger
-	processor             *event_processors.EventProcessor
-	apiStore              *models.ApiStore
-	subscriptionFlagStore models.Flagger
-	kafkaConfig           kafka.ServerConfig
-	chargeCacheStore      *models.ChargeCache
+	ctx              context.Context
+	logger           *slog.Logger
+	processor        *event_processors.EventProcessor
+	apiStore         *models.ApiStore
+	kafkaConfig      kafka.ServerConfig
+	chargeCacheStore *models.ChargeCache
 )
 
 func initProducer(context context.Context, topicEnv string) utils.Result[*kafka.Producer] {
@@ -170,7 +169,6 @@ func StartProcessingEvents() {
 		utils.CaptureError(err)
 		panic(err.Error())
 	}
-	subscriptionFlagStore = flagger
 	defer flagger.Close()
 
 	cacher, err := initChargeCacheStore()
@@ -190,6 +188,7 @@ func StartProcessingEvents() {
 			eventsDeadLetterQueueResult.Value(),
 			logger,
 		),
+		event_processors.NewSubscriptionRefreshService(flagger),
 		event_processors.NewCacheService(chargeCacheStore),
 	)
 


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This pull extract the subscription refresh flagging logic from the events processor into a new dedicated `SubscriptionRefreshService` sub-service.
It clearly separates the flagging logic from the other parts of the processing logic. It make the code easier to maintain and test.