### PR TITLE
fix(events-processor): Fix in advance check when no charges

### DIFF
--- a/events-processor/processors/events.go
+++ b/events-processor/processors/events.go
@@ -102,7 +102,7 @@ func processEvent(event *models.Event) utils.Result[*models.EnrichedEvent] {
 	if enrichedEvent.Subscription != nil && event.NotAPIPostProcessed() {
 		payInAdvance := false
 		for _, ev := range enrichedEvents {
-			if ev.FlatFilter.PayInAdvance {
+			if ev.FlatFilter != nil && ev.FlatFilter.PayInAdvance {
 				payInAdvance = true
 				break
 			}


### PR DESCRIPTION
This PR fixes an error when a an event matching a billable metric and a subscription does not match any charges.

The check for the presence of a pay in advance charge must first check the presence of a charge