### PR TITLE
fix(events-processor): Ensure grouped by is not nil

### DIFF
--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -71,6 +71,7 @@ func (ev *Event) ToEnrichedEvent() utils.Result[*EnrichedEvent] {
 		Properties:              ev.Properties,
 		PreciseTotalAmountCents: ev.PreciseTotalAmountCents,
 		Source:                  ev.Source,
+		GroupedBy:               make(map[string]string),
 	}
 
 	timestampResult := utils.ToFloat64Timestamp(ev.Timestamp)

--- a/events-processor/models/event_test.go
+++ b/events-processor/models/event_test.go
@@ -37,6 +37,7 @@ func TestToEnrichedEvent(t *testing.T) {
 		assert.Equal(t, event.Source, ere.Source)
 		assert.Equal(t, 1741007009.0, ere.Timestamp)
 		assert.Equal(t, expectedTime, ere.Time)
+		assert.Equal(t, map[string]string{}, ere.GroupedBy)
 	})
 
 	t.Run("With unsupported time format", func(t *testing.T) {

--- a/events-processor/processors/event_processors/enrichment_service.go
+++ b/events-processor/processors/event_processors/enrichment_service.go
@@ -142,6 +142,7 @@ func (s *EventEnrichmentService) enrichWithChargeInfo(enrichedEvent *models.Enri
 
 		// Create a copy of the enriched event for this filter
 		enrichedEventCopy := *enrichedEvent
+		enrichedEventCopy.GroupedBy = make(map[string]string)
 
 		// Populate charge information
 		enrichedEventCopy.FlatFilter = matchingFilter
@@ -163,7 +164,6 @@ func enrichWithPricingGroupKeys(event *models.EnrichedEvent) {
 		return
 	}
 
-	event.GroupedBy = make(map[string]string)
 	for _, key := range event.FlatFilter.PricingGroupKeys {
 		event.GroupedBy[key] = fmt.Sprintf("%v", event.Properties[key])
 	}

--- a/events-processor/processors/event_processors/enrichment_service_test.go
+++ b/events-processor/processors/event_processors/enrichment_service_test.go
@@ -300,10 +300,12 @@ func TestEnrichEvent(t *testing.T) {
 		eventResult1 := result.Value()[0]
 		assert.Equal(t, "12", *eventResult1.Value)
 		assert.Equal(t, "charge_id1", *eventResult1.ChargeID)
+		assert.Equal(t, map[string]string{}, eventResult1.GroupedBy)
 
 		eventResult2 := result.Value()[1]
 		assert.Equal(t, "12", *eventResult2.Value)
 		assert.Equal(t, "charge_id2", *eventResult2.ChargeID)
+		assert.Equal(t, map[string]string{}, eventResult2.GroupedBy)
 	})
 
 	t.Run("When event source is not post process on API with a flat filter with pricing group keys", func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR ensures that the enriched events produced in the `events_enriched` and `events_enriched_expanded` topics are not nil but default to an empty `JSON`.

The end-goal is to fix the ingestion in Clickhouse cloud with clickpipe