### PR TITLE
fix(docker): Fix development Docker Compose file

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -111,12 +111,18 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     command: ["./scripts/migrate.dev.sh"]
     build:
       context: ./api
       dockerfile: $LAGO_PATH/api/Dockerfile.dev
     volumes:
       - $LAGO_PATH/api:/app:delegated
+    env_file:
+      - path: ./.env.development.default
+      - path: ./.env.development
+        required: false
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@db:5432/${POSTGRES_DB:-lago}
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -113,6 +113,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      clickhouse:
+        condition: service_healthy
     command: ["./scripts/migrate.dev.sh"]
     build:
       context: ./api
@@ -137,6 +139,8 @@ services:
       db:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      clickhouse:
         condition: service_healthy
     volumes:
       - $LAGO_PATH/api:/app:delegated
@@ -337,9 +341,12 @@ services:
     hostname: clickhouse
     user: "101:101"
     depends_on:
-      - db
-      - redpanda
-      - redpandacreatetopics
+      db:
+        condition: service_healthy
+      redpanda:
+        condition: service_healthy
+      redpandacreatetopics:
+        condition: service_completed_successfully
     volumes:
       - clickhouse_data_dev:/var/lib/clickhouse
       - ./extra/clickhouse/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
@@ -347,3 +354,9 @@ services:
     ports:
       - 9000:9000
       - 8123:8123
+    healthcheck:
+      test: ["CMD", "clickhouse-client", "--password", "default", "--query", "SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -289,11 +289,18 @@ services:
     ports:
       - 9092:9092
       - 19092:19092
+    healthcheck:
+      test: ["CMD", "curl", "http://localhost:9644/v1/status/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   redpandacreatetopics:
     image: docker.redpanda.com/redpandadata/redpanda:v23.2.9
     depends_on:
-      - redpanda
+      redpanda:
+        condition: service_healthy
     entrypoint: >
       rpk topic create events-raw events_enriched events_charged_in_advance events_dead_letter activity_logs api_logs --brokers redpanda:9092
 


### PR DESCRIPTION
## Context

When running `lago up -d`, you may (randomly) run into a few issues:

* Failure to connect to Redis from the `migrate` container:

  ```ruby
  RedisClient::CannotConnectError: Connection refused - connect(2) for 127.0.0.1:6379 (redis://localhost:6379) (RedisClient::CannotConnectError)
  /app/app/services/plans/create_service.rb:160:in 'Plans::CreateService#track_plan_created'
  /app/app/services/plans/create_service.rb:85:in 'Plans::CreateService#call'
  /app/app/services/base_service.rb:291:in 'BaseService#call_with_activity_log'
  /app/app/services/base_service.rb:241:in 'block in BaseService.call'
  /app/app/services/base_service.rb:237:in 'BaseService.call'
  /app/app/services/base_service.rb:255:in 'BaseService.call!'
  /app/db/seeds/01_base.rb:60:in '<main>'
  /app/db/seeds.rb:4:in 'Kernel#load'
  /app/db/seeds.rb:4:in 'block in <main>'
  /app/db/seeds.rb:3:in 'Array#each'
  /app/db/seeds.rb:3:in '<main>'
  Tasks: TOP => db:prepare
  (See full trace by running task with --trace)
  ````

* Failure to create topic on Redpanda from the `redpandacreatetopics` container:

  ```
  unable to create topics [events-raw events_enriched events_charged_in_advance events_dead_letter activity_logs api_logs]: unable to dial: dial tcp 172.18.0.2:9092: connect: connection refused
  ```

* Failure to connect to Clickhouse from the `migrate` container

  ```sh
  bin/rails aborted!
  Errno::ECONNREFUSED: Failed to open TCP connection to clickhouse:8123 (Connection refused - connect(2) for "clickhouse" port 8123) (Errno::ECONNREFUSED)
  
  
  Caused by:
  Errno::ECONNREFUSED: Connection refused - connect(2) for "clickhouse" port 8123 (Errno::ECONNREFUSED)
  
  Tasks: TOP => db:prepare
  (See full trace by running task with --trace)
  ```

This is due to the following:

- `migrate` container has no dependency on `redis` and `clickhouse` and did not load the environment to properly connect to Redis
- `clickhouse` had no health check and its dependencies did not include a health check
- `redpanda` had no health check and therefore `redpandacreatetopics` dependency on `redpanda` did not include a health check

# Description

This fixes the aforementioned issues.