### PR TITLE
fix(docker): make rpk create topic idempotent

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -305,8 +305,19 @@ services:
     depends_on:
       redpanda:
         condition: service_healthy
-    entrypoint: >
-      rpk topic create events-raw events_enriched events_charged_in_advance events_dead_letter activity_logs api_logs --brokers redpanda:9092
+    # https://github.com/redpanda-data/redpanda/issues/6651
+    entrypoint: create-topics
+    command:
+      - events-raw
+      - events_enriched
+      - events_charged_in_advance
+      - events_dead_letter
+      - activity_logs
+      - api_logs
+    volumes:
+      - ./scripts/create-topics.sh:/usr/local/bin/create-topics
+    environment:
+      - RPK_BROKERS=redpanda:9092
 
   redpanda-console:
     image: docker.redpanda.com/redpandadata/console:v2.3.1

--- a/scripts/create-topics.sh
+++ b/scripts/create-topics.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# due to https://github.com/redpanda-data/redpanda/issues/6651
+# we need to create the topics only if they don't exist
+# this script gets the list of topics from the arguments
+# and creates them if they don't exist, creation is not invoked if the topics already exist
+rpk topic list | awk -v expected="$*" '
+BEGIN { 
+    n = split(expected, exp_array, " ")
+    for (i = 1; i <= n; i++)  expected_topics[exp_array[i]] = 1
+} NR > 1 { 
+    actual_topics[$1] = 1 
+} END {
+    for (topic in expected_topics) {
+        if (!(topic in actual_topics)) printf "%s ", topic
+    }
+}' | xargs -r rpk topic create


### PR DESCRIPTION
When the redpandacreatetopics container is run it invokes the `rpk create topics` command, which is not idempotent, see: https://github.com/redpanda-data/redpanda/issues/6651

This patch replace the command with a script checking which topic has been created and piping the missing one to the create command.
