### PR TITLE
fix(events-processor): Set version for `events-processor` dev container dependencies

### DIFF
--- a/events-processor/Dockerfile.dev
+++ b/events-processor/Dockerfile.dev
@@ -8,8 +8,8 @@ FROM golang:1.24 AS go-build
 
 WORKDIR /app
 
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
-RUN go install github.com/air-verse/air@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.25
+RUN go install github.com/air-verse/air@v1.62
 
 COPY --from=rust-build /lago-expression/target/release/libexpression_go.so /usr/lib/libexpression_go.so
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Context

The latest version of [`air`](github.com/air-verse/air) requires Go >= 1.25, causing the build of the dev container of `events-processor` to fail:

```sh
 > [go-build 4/7] RUN go install github.com/air-verse/air@latest:                                      
0.382 go: downloading github.com/air-verse/air v1.63.0                                                 
0.484 go: github.com/air-verse/air@latest: github.com/air-verse/air@v1.63.0 requires go >= 1.25 (running go 1.24.7; GOTOOLCHAIN=local)                                                                        
------
Dockerfile.dev:12

--------------------

  10 |     

  11 |     RUN go install github.com/go-delve/delve/cmd/dlv@latest

  12 | >>> RUN go install github.com/air-verse/air@latest

  13 |     

  14 |     COPY --from=rust-build /lago-expression/target/release/libexpression_go.so /usr/lib/libexpression_go.so

--------------------

failed to solve: process "/bin/sh -c go install github.com/air-verse/air@latest" did not complete successfully: exit code: 1
```

## Description

This uses a fixed version for `air` and `dlv` rather than `latest` to avoid this issue.