### PR TITLE
feat(ai-agent): Add LAGO_WS_API_URL env variable

### DIFF
--- a/.env.development.default
+++ b/.env.development.default
@@ -1,4 +1,5 @@
 LAGO_API_URL=https://api.lago.dev
+LAGO_API_WS_URL=wss://api.lago.dev/cable
 LAGO_FRONT_URL=https://app.lago.dev
 
 # Feature flags
@@ -48,6 +49,7 @@ SIDEKIQ_WEBHOOK=false
 # External API keys
 LAGO_DATA_API_BEARER_TOKEN=changeme
 LAGO_LICENSE=
+MISTRAL_API_KEY=
 NANGO_SECRET_KEY=
 SEGMENT_WRITE_KEY=
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Note that if our docker server is not at http://localhost, the following env var
 
 ```
 LAGO_API_URL="http://192.168.122.71:3000"
+LAGO_API_WS_URL="wss://192.168.122.71:3000/cable"
 LAGO_FRONT_URL="http://192.168.122.71"
 ```
 


### PR DESCRIPTION
The goal of this PR is to introduce a new environment variable for defining the websocket api URL.