### PR TITLE
chore(events-processor): do not setup otel if endpoint not provided

### DIFF
--- a/events-processor/processors/processors.go
+++ b/events-processor/processors/processors.go
@@ -103,10 +103,11 @@ func StartProcessingEvents() {
 		With("service", "post_process")
 	slog.SetDefault(logger)
 
-	if os.Getenv("ENV") == "production" {
+	otelEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if os.Getenv("ENV") == "production" && otelEndpoint != "" {
 		telemetryCfg := tracer.TracerConfig{
 			ServiceName: os.Getenv("OTEL_SERVICE_NAME"),
-			EndpointURL: os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+			EndpointURL: otelEndpoint,
 			Insecure:    os.Getenv("OTEL_INSECURE"),
 		}
 		tracer.InitOTLPTracer(telemetryCfg)

--- a/events-processor/processors/processors.go
+++ b/events-processor/processors/processors.go
@@ -104,7 +104,7 @@ func StartProcessingEvents() {
 	slog.SetDefault(logger)
 
 	otelEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-	if os.Getenv("ENV") == "production" && otelEndpoint != "" {
+	if otelEndpoint != "" {
 		telemetryCfg := tracer.TracerConfig{
 			ServiceName: os.Getenv("OTEL_SERVICE_NAME"),
 			EndpointURL: otelEndpoint,


### PR DESCRIPTION
OpenTelemetry is not a requirement for the system to boot up. This patch ensure that it become optional, even in a production environment. This change is mostly to bring consistency across all our services, which do not require OpenTelemetry as well.

