### PR TITLE
fix: Build of single docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,15 +39,15 @@ FROM ruby:$RUBY_VERSION-slim
 WORKDIR /app
 
 RUN apt-get update -y && \
-  apt-get install curl ca-certificates gnupg software-properties-common -y && \
+  apt-get install curl ca-certificates gnupg -y && \
   curl -fsSL https://postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /usr/share/keyrings/postgresql-archive-keyring.gpg > /dev/null && \
   echo deb [arch=amd64,arm64,ppc64e1 signed-by=/usr/share/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main | tee /etc/ap && \
   curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
   chmod a+r /etc/apt/keyrings/docker.asc && \
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
   apt-get update && \
-  apt-get install nginx xz-utils git libpq-dev postgresql-15 redis-server docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y && \
-  apt-get remove software-properties-common apt-transport-https -y
+  apt-get install nginx xz-utils git libpq-dev postgresql-17 redis-server docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y && \
+  apt-get remove apt-transport-https -y
 
 COPY ./docker/nginx.conf /etc/nginx/sites-enabled/default
 


### PR DESCRIPTION
This PR fixes the build of the single docker image that was failing since the upgrade to ruby 3.4.5 https://github.com/getlago/lago/pull/571.

The reason of the failure is that ruby-slim 3.4.5 now relies on Debian Trixie, and some package have been updated (`postgresql`) or removed (`software-properties-common`)