### PR TITLE
feat(live_agg): Enable pre-aggregation flow

### DIFF
--- a/events-processor/processors/events_processor/enrichment_service.go
+++ b/events-processor/processors/events_processor/enrichment_service.go
@@ -110,8 +110,7 @@ func (s *EventEnrichmentService) enrichWithSubscription(enrichedEvent *models.En
 }
 
 func (s *EventEnrichmentService) enrichWithChargeInfo(enrichedEvent *models.EnrichedEvent) utils.Result[[]*models.EnrichedEvent] {
-	// TODO(pre-aggregation): Remove the NotAPIPostProcessed condition to enable pre-aggregation
-	if !enrichedEvent.InitialEvent.NotAPIPostProcessed() || enrichedEvent.Subscription == nil {
+	if enrichedEvent.Subscription == nil {
 		return utils.SuccessResult([]*models.EnrichedEvent{enrichedEvent})
 	}
 

--- a/events-processor/processors/events_processor/enrichment_service_test.go
+++ b/events-processor/processors/events_processor/enrichment_service_test.go
@@ -44,53 +44,6 @@ func TestEnrichEvent(t *testing.T) {
 		assert.Equal(t, "Error fetching billable metric", result.ErrorMessage())
 	})
 
-	t.Run("When event source is post processed on API and the result is successful", func(t *testing.T) {
-		processor, mockedStore, delete := setupEnrichmentTestEnv(t)
-		defer delete()
-
-		properties := map[string]any{
-			"api_requests": "12.0",
-		}
-
-		event := models.Event{
-			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
-			ExternalSubscriptionID: "sub_id",
-			Code:                   "api_calls",
-			Timestamp:              1741007009,
-			Source:                 models.HTTP_RUBY,
-			Properties:             properties,
-			SourceMetadata: &models.SourceMetadata{
-				ApiPostProcess: true,
-			},
-		}
-
-		bm := models.BillableMetric{
-			ID:              "bm123",
-			OrganizationID:  event.OrganizationID,
-			Code:            event.Code,
-			AggregationType: models.AggregationTypeSum,
-			FieldName:       "api_requests",
-			Expression:      "",
-			CreatedAt:       time.Now(),
-			UpdatedAt:       time.Now(),
-		}
-		mockBmLookup(mockedStore, &bm)
-
-		sub := models.Subscription{ID: "sub123", PlanID: "plan123"}
-		mockSubscriptionLookup(mockedStore, &sub)
-
-		result := processor.EnrichEvent(&event)
-
-		assert.True(t, result.Success())
-		assert.Equal(t, 1, len(result.Value()))
-
-		eventResult := result.Value()[0]
-		assert.Equal(t, "12.0", *eventResult.Value)
-		assert.Equal(t, "sum", eventResult.AggregationType)
-		assert.Equal(t, "sub123", eventResult.SubscriptionID)
-		assert.Equal(t, "plan123", eventResult.PlanID)
-	})
-
 	t.Run("When timestamp is invalid", func(t *testing.T) {
 		processor, mockedStore, delete := setupEnrichmentTestEnv(t)
 		defer delete()
@@ -153,7 +106,7 @@ func TestEnrichEvent(t *testing.T) {
 		assert.Equal(t, "Error evaluating custom expression", result.ErrorMessage())
 	})
 
-	t.Run("When event source is not post process on API", func(t *testing.T) {
+	t.Run("With a flat filter", func(t *testing.T) {
 		processor, mockedStore, delete := setupEnrichmentTestEnv(t)
 		defer delete()
 
@@ -194,7 +147,7 @@ func TestEnrichEvent(t *testing.T) {
 		assert.Equal(t, "12", *eventResult.Value)
 	})
 
-	t.Run("When event source is not post process on API with multiple flat filters", func(t *testing.T) {
+	t.Run("With multiple flat filters", func(t *testing.T) {
 		processor, mockedStore, delete := setupEnrichmentTestEnv(t)
 		defer delete()
 
@@ -272,7 +225,7 @@ func TestEnrichEvent(t *testing.T) {
 		assert.Equal(t, map[string]string{}, eventResult2.GroupedBy)
 	})
 
-	t.Run("When event source is not post process on API with a flat filter with pricing group keys", func(t *testing.T) {
+	t.Run("With a flat filter with pricing group keys", func(t *testing.T) {
 		processor, mockedStore, delete := setupEnrichmentTestEnv(t)
 		defer delete()
 

--- a/events-processor/processors/events_processor/event_producer_service.go
+++ b/events-processor/processors/events_processor/event_producer_service.go
@@ -42,7 +42,7 @@ func (eps *EventProducerService) ProduceEnrichedEvent(context context.Context, e
 	}
 }
 
-func (eps *EventProducerService) ProduceEnrichedExpendedEvent(context context.Context, event *models.EnrichedEvent) {
+func (eps *EventProducerService) ProduceEnrichedExpandedEvent(context context.Context, event *models.EnrichedEvent) {
 	chargeID := ""
 	if event.ChargeID != nil {
 		chargeID = *event.ChargeID

--- a/events-processor/processors/events_processor/event_producer_service_test.go
+++ b/events-processor/processors/events_processor/event_producer_service_test.go
@@ -74,7 +74,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 			Code:                   "api_calls",
 		}
 
-		producerService.ProduceEnrichedExpendedEvent(context.Background(), &event)
+		producerService.ProduceEnrichedExpandedEvent(context.Background(), &event)
 
 		assert.Equal(t, 1, enrichedExpandedProducer.ExecutionCount)
 		assert.Equal(
@@ -97,7 +97,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 			ChargeID:               utils.StringPtr("charge_id"),
 		}
 
-		producerService.ProduceEnrichedExpendedEvent(context.Background(), &event)
+		producerService.ProduceEnrichedExpandedEvent(context.Background(), &event)
 
 		assert.Equal(t, 1, enrichedExpandedProducer.ExecutionCount)
 		assert.Equal(
@@ -120,7 +120,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 			ChargeFilterID:         utils.StringPtr("charge_filter_id"),
 		}
 
-		producerService.ProduceEnrichedExpendedEvent(context.Background(), &event)
+		producerService.ProduceEnrichedExpandedEvent(context.Background(), &event)
 
 		assert.Equal(t, 1, enrichedExpandedProducer.ExecutionCount)
 		assert.Equal(
@@ -143,7 +143,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 			GroupedBy:              map[string]string{"country": "US", "type": "debit"},
 		}
 
-		producerService.ProduceEnrichedExpendedEvent(context.Background(), &event)
+		producerService.ProduceEnrichedExpandedEvent(context.Background(), &event)
 
 		assert.Equal(t, 1, enrichedExpandedProducer.ExecutionCount)
 		assert.Equal(
@@ -166,7 +166,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 			GroupedBy:              map[string]string{"type": "debit", "country": "US"},
 		}
 
-		producerService.ProduceEnrichedExpendedEvent(context.Background(), &event)
+		producerService.ProduceEnrichedExpandedEvent(context.Background(), &event)
 
 		assert.Equal(t, 1, enrichedExpandedProducer.ExecutionCount)
 		assert.Equal(

--- a/events-processor/processors/events_processor/processor.go
+++ b/events-processor/processors/events_processor/processor.go
@@ -120,13 +120,14 @@ func (processor *EventProcessor) processEvent(ctx context.Context, event *models
 		return nil
 	})
 
-	// TODO(pre-aggregation): Uncomment to enable the feature
-	// for _, ev := range enrichedEvents {
-	// 	errgroup.Go(func() error {
-	//		processor.ProducerService.ProduceEnrichedExpendedEvent(ctx, ev)
-	//		return nil
-	//	})
-	// }
+	for _, ev := range enrichedEvents {
+		if ev.ChargeID != nil {
+			errgroup.Go(func() error {
+				processor.ProducerService.ProduceEnrichedExpandedEvent(ctx, ev)
+				return nil
+			})
+		}
+	}
 
 	if enrichedEvent.Subscription != nil && event.NotAPIPostProcessed() {
 		payInAdvance := false

--- a/events-processor/processors/events_processor/processor_test.go
+++ b/events-processor/processors/events_processor/processor_test.go
@@ -186,6 +186,17 @@ func TestProcessEvent(t *testing.T) {
 		sub := models.Subscription{ID: "sub123", PlanID: "plan123"}
 		mockSubscriptionLookup(mockedStore, &sub)
 
+		mockFlatFiltersLookup(mockedStore, []*models.FlatFilter{
+			{
+				OrganizationID:     event.OrganizationID,
+				BillableMetricCode: event.Code,
+				PlanID:             "plan_id",
+				ChargeID:           "charge_idxx",
+				ChargeUpdatedAt:    time.Now(),
+				PayInAdvance:       true,
+			},
+		})
+
 		result := processor.processEvent(context.Background(), &event)
 
 		assert.True(t, result.Success())
@@ -198,7 +209,7 @@ func TestProcessEvent(t *testing.T) {
 		// TODO: Improve this by using channels in the producers methods
 		time.Sleep(50 * time.Millisecond)
 		assert.Equal(t, 1, testProducers.enrichedProducer.ExecutionCount)
-		// TODO(pre-aggregation): assert.Equal(t, 1, testProducers.enrichedExpandedProducer.ExecutionCount)
+		assert.Equal(t, 1, testProducers.enrichedExpandedProducer.ExecutionCount)
 	})
 
 	t.Run("When event source is not post process on API when timestamp is invalid", func(t *testing.T) {
@@ -388,7 +399,7 @@ func TestProcessEvent(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		assert.Equal(t, 1, testProducers.inAdvanceProducer.ExecutionCount)
 		assert.Equal(t, 1, testProducers.enrichedProducer.ExecutionCount)
-		// TODO(pre-aggregation): assert.Equal(t, 1, testProducers.enrichedExpandedProducer.ExecutionCount)
+		assert.Equal(t, 1, testProducers.enrichedExpandedProducer.ExecutionCount)
 
 		assert.Equal(t, 1, flagger.ExecutionCount)
 	})
@@ -462,7 +473,7 @@ func TestProcessEvent(t *testing.T) {
 		// TODO: Improve this by using channels in the producers methods
 		time.Sleep(50 * time.Millisecond)
 		assert.Equal(t, 1, testProducers.enrichedProducer.ExecutionCount)
-		// TODO(pre-aggregation): assert.Equal(t, 2, testProducers.enrichedExpandedProducer.ExecutionCount)
+		assert.Equal(t, 2, testProducers.enrichedExpandedProducer.ExecutionCount)
 	})
 
 	t.Run("When event source is not post processed on API and it matches no charges", func(t *testing.T) {


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic, it follows https://github.com/getlago/lago-api/pull/4277.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR enables the live aggregation feature on the event processor side, making sure that the `events_enriched_expanded` table will be populated