### PR TITLE
test: Fix flaky `events-processor` test

### DIFF
--- a/events-processor/README.md
+++ b/events-processor/README.md
@@ -5,7 +5,6 @@ This service is in charge of providing a post-process for events in high volume 
 
 This service need to be configured with Clickhouse and Redpanda. Please contact us for further informations.
 
-
 ## How to run it
 
 With the docker compose environment:
@@ -16,10 +15,18 @@ go build -o event_processors .
 ./event_processors
 ```
 
-## In development
+## Development
 
-```
+### Running
+
+```shell
 lago up -d events-processor
+```
+
+### Testing
+
+```shell
+lago exec events-processor go test ./...
 ```
 
 ## Configuration

--- a/events-processor/processors/event_processors/enrichment_service_test.go
+++ b/events-processor/processors/event_processors/enrichment_service_test.go
@@ -1,6 +1,7 @@
 package event_processors
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -297,12 +298,17 @@ func TestEnrichEvent(t *testing.T) {
 		assert.True(t, result.Success())
 		assert.Equal(t, 2, len(result.Value()))
 
-		eventResult1 := result.Value()[0]
+		events := result.Value()
+		sort.Slice(events, func(i, j int) bool {
+			return *events[i].ChargeID < *events[j].ChargeID
+		})
+
+		eventResult1 := events[0]
 		assert.Equal(t, "12", *eventResult1.Value)
 		assert.Equal(t, "charge_id1", *eventResult1.ChargeID)
 		assert.Equal(t, map[string]string{}, eventResult1.GroupedBy)
 
-		eventResult2 := result.Value()[1]
+		eventResult2 := events[1]
 		assert.Equal(t, "12", *eventResult2.Value)
 		assert.Equal(t, "charge_id2", *eventResult2.ChargeID)
 		assert.Equal(t, map[string]string{}, eventResult2.GroupedBy)


### PR DESCRIPTION
## Context

One of the `events-processor` is flaky due to random order:

```sh
--- FAIL: TestEnrichEvent (0.01s)
    --- FAIL: TestEnrichEvent/When_event_source_is_not_post_process_on_API_with_multiple_flat_filters (0.00s)
        enrichment_service_test.go:302: 
                Error Trace:    /app/processors/event_processors/enrichment_service_test.go:302
                Error:          Not equal: 
                                expected: "charge_id1"
                                actual  : "charge_id2"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -charge_id1
                                +charge_id2
                Test:           TestEnrichEvent/When_event_source_is_not_post_process_on_API_with_multiple_flat_filters
        enrichment_service_test.go:307: 
                Error Trace:    /app/processors/event_processors/enrichment_service_test.go:307
                Error:          Not equal: 
                                expected: "charge_id2"
                                actual  : "charge_id1"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -charge_id2
                                +charge_id1
                Test:           TestEnrichEvent/When_event_source_is_not_post_process_on_API_with_multiple_flat_filters
FAIL
FAIL    github.com/getlago/lago/events-processor/processors/event_processors    0.020s
```

## Description

This fixes it by ordering the result before doing assertions.

It also updates the README to explain how to run tests.