### PR TITLE
chore(docker): remove $LAGO_PATH from docker compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -71,9 +71,9 @@ services:
       - api
     build:
       context: ./front
-      dockerfile: $LAGO_PATH/front/Dockerfile.dev
+      dockerfile: Dockerfile.dev
     volumes:
-      - $LAGO_PATH/front:/app:delegated
+      - ./front:/app:delegated
       - front_node_modules_dev:/app/node_modules:delegated
       - front_dist_dev:/app/dist:delegated
     environment:
@@ -118,9 +118,9 @@ services:
     command: ["./scripts/migrate.dev.sh"]
     build:
       context: ./api
-      dockerfile: $LAGO_PATH/api/Dockerfile.dev
+      dockerfile: Dockerfile.dev
     volumes:
-      - $LAGO_PATH/api:/app:delegated
+      - ./api:/app:delegated
     env_file:
       - path: ./.env.development.default
       - path: ./.env.development
@@ -143,7 +143,7 @@ services:
       clickhouse:
         condition: service_healthy
     volumes:
-      - $LAGO_PATH/api:/app:delegated
+      - ./api:/app:delegated
     env_file:
       - path: ./.env.development.default
       - path: ./.env.development
@@ -175,7 +175,7 @@ services:
       api:
         condition: service_started
     volumes:
-      - $LAGO_PATH/api:/app:delegated
+      - ./api:/app:delegated
     env_file:
       - path: ./.env.development.default
       - path: ./.env.development
@@ -222,7 +222,7 @@ services:
       api:
         condition: service_started
     volumes:
-      - $LAGO_PATH/api:/app:delegated
+      - ./api:/app:delegated
     env_file:
       - path: ./.env.development.default
       - path: ./.env.development
@@ -239,7 +239,7 @@ services:
     restart: unless-stopped
     build:
       context: ./events-processor
-      dockerfile: $LAGO_PATH/events-processor/Dockerfile.dev
+      dockerfile: Dockerfile.dev
     depends_on:
       - db
       - redpanda
@@ -249,7 +249,7 @@ services:
       - path: ./.env.development
         required: false
     volumes:
-      - $LAGO_PATH/events-processor:/app:delegated
+      - ./events-processor:/app:delegated
 
   pdf:
     image: getlago/lago-gotenberg:8


### PR DESCRIPTION
The $LAGO_PATH variable is not needed in docker compose since all paths are evaluated from the docker-compose file location.
