### PR TITLE
misc(sidekiq): Allow to use Sidekiq Pro in dev environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -154,6 +154,8 @@ services:
       - DATABASE_TEST_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@db:5432/lago_test
       - GOOGLE_AUTH_CLIENT_ID=${GOOGLE_AUTH_CLIENT_ID:-}
       - GOOGLE_AUTH_CLIENT_SECRET=${GOOGLE_AUTH_CLIENT_SECRET:-}
+      - BUNDLE_WITH=${BUNDLE_WITH:-}
+      - BUNDLE_GEMS__CONTRIBSYS__COM=${BUNDLE_GEMS__CONTRIBSYS__COM:-}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api_http.rule=Host(`api.lago.dev`)"
@@ -176,6 +178,9 @@ services:
         condition: service_started
     volumes:
       - ./api:/app:delegated
+    environment:
+      - BUNDLE_WITH=${BUNDLE_WITH:-}
+      - BUNDLE_GEMS__CONTRIBSYS__COM=${BUNDLE_GEMS__CONTRIBSYS__COM:-}
     env_file:
       - path: ./.env.development.default
       - path: ./.env.development
@@ -218,6 +223,9 @@ services:
     container_name: lago_api_clock_dev
     restart: unless-stopped
     command: bash -c "bundle install && ./scripts/start.clock.sh"
+    environment:
+      - BUNDLE_WITH=${BUNDLE_WITH:-}
+      - BUNDLE_GEMS__CONTRIBSYS__COM=${BUNDLE_GEMS__CONTRIBSYS__COM:-}
     depends_on:
       api:
         condition: service_started


### PR DESCRIPTION
## Context

Today, we are using Sidekiq to handle our background jobs. While it works well for most of our needs, we are reaching some limitations with the open-source version, particularly around job reliability during high load.

Sidekiq uses `BRPOP` to fetch a job from the queue in Redis. This is very efficient and simple but it has one drawback: the job is now removed from Redis. If Sidekiq crashes while processing that job, it is lost forever.

## Description

https://github.com/getlago/lago-api/pull/4482 added `sidekiq-pro` as an optional dependency which can be install when building the Docker image.

This allow to easily start the development container with or without Sidekiq Pro by specifying `BUNDLE_WITH` and `BUNDLE_GEMS__CONTRIBSYS__COM`:

```sh
BUNDLE_WITH='sidekiq-pro' BUNDLE_GEMS__CONTRIBSYS__COM='xxx:yyy' lago up -d api api-worker
```