### PR TITLE
misc(events-processor): Keep track of go routines

### DIFF
--- a/events-processor/processors/events_processor/processor_test.go
+++ b/events-processor/processors/events_processor/processor_test.go
@@ -186,7 +186,6 @@ func TestProcessEvent(t *testing.T) {
 		sub := models.Subscription{ID: "sub123", PlanID: "plan123"}
 		mockSubscriptionLookup(mockedStore, &sub)
 
-<<<<<<< HEAD
 		mockFlatFiltersLookup(mockedStore, []*models.FlatFilter{
 			{
 				OrganizationID:     event.OrganizationID,
@@ -198,8 +197,6 @@ func TestProcessEvent(t *testing.T) {
 			},
 		})
 
-=======
->>>>>>> cf2a092 (Simplify code)
 		result := processor.processEvent(context.Background(), &event)
 
 		assert.True(t, result.Success())

--- a/events-processor/processors/main_processor.go
+++ b/events-processor/processors/main_processor.go
@@ -227,7 +227,7 @@ func StartProcessingEvents(ctx context.Context, config *Config) {
 			Topic:         os.Getenv(envLagoKafkaRawEventsTopic),
 			ConsumerGroup: os.Getenv(envLagoKafkaConsumerGroup),
 			ProcessRecords: func(records []*kgo.Record) []*kgo.Record {
-				return processor.ProcessEvents(records)
+				return processor.ProcessEvents(ctx, records)
 			},
 		})
 	if err != nil {

--- a/events-processor/processors/main_processor.go
+++ b/events-processor/processors/main_processor.go
@@ -237,10 +237,6 @@ func StartProcessingEvents(ctx context.Context, config *Config) {
 	}
 
 	config.Logger.Info("Starting event consumer")
-	if err := cg.Start(ctx); err != nil && err != context.Canceled {
-		config.Logger.Error("Consumer stopped with error", slog.String("error", err.Error()))
-		utils.CaptureError(err)
-	}
-
+	cg.Start(ctx)
 	config.Logger.Info("Event processor stopped")
 }

--- a/events-processor/processors/main_processor.go
+++ b/events-processor/processors/main_processor.go
@@ -52,7 +52,7 @@ type Config struct {
 	UseTelemetry bool
 }
 
-func initProducer(context context.Context, topicEnv string) utils.Result[*kafka.Producer] {
+func initProducer(ctx context.Context, topicEnv string) utils.Result[*kafka.Producer] {
 	if os.Getenv(topicEnv) == "" {
 		return utils.FailedResult[*kafka.Producer](fmt.Errorf("%s variable is required", topicEnv))
 	}
@@ -68,7 +68,7 @@ func initProducer(context context.Context, topicEnv string) utils.Result[*kafka.
 		return utils.FailedResult[*kafka.Producer](err)
 	}
 
-	err = producer.Ping(context)
+	err = producer.Ping(ctx)
 	if err != nil {
 		return utils.FailedResult[*kafka.Producer](err)
 	}


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic, it follows https://github.com/getlago/lago/pull/606

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR adds a grecefull shutdown logic to the events_processor, and keeps tracks of go routine to make sure that it waits for the ongoing task to be finished before shutting down the application. It also improves the recovery in case of system failures (panic, unhandled errors...)