### PR TITLE
misc(docker): Add healthcheck to development `api` container

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -133,6 +133,12 @@ services:
     container_name: lago_api_dev
     restart: unless-stopped
     command: ["./scripts/start.dev.sh"]
+    healthcheck:
+      test: curl -f http://localhost:3000/health || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     depends_on:
       migrate:
         condition: service_completed_successfully


### PR DESCRIPTION
## Context

There is currently no health check defined on the `api` development container. This prevents us from properly knowing when all services are ready. For instance, one may want to run a script that executes a command right after all services are ready:

```sh
# lago-up.sh

lago up -d --wait
lago exec -e RAILS_ENV=test api bundle exec rails db:migrate
```

This might currently fail as the container could still be running `bundle install` when running the second command.

## Description

This adds a health check on the `api` container.