### PR TITLE
fix(events-processor): Move from cache deletion to cache expiration

### DIFF
--- a/events-processor/models/charge_cache.go
+++ b/events-processor/models/charge_cache.go
@@ -40,5 +40,5 @@ func (cache *ChargeCache) Expire(ff *FlatFilter, subID string) utils.Result[bool
 	cacheKey := strings.Join(keyParts, "/")
 
 	// Remove the cache entry
-	return cache.CacheStore.DeleteKey(cacheKey)
+	return cache.CacheStore.ExpireKey(cacheKey)
 }

--- a/events-processor/tests/mocked_cache_store.go
+++ b/events-processor/tests/mocked_cache_store.go
@@ -12,7 +12,7 @@ func (mcs *MockCacheStore) Close() error {
 	return nil
 }
 
-func (mcs *MockCacheStore) DeleteKey(key string) utils.Result[bool] {
+func (mcs *MockCacheStore) ExpireKey(key string) utils.Result[bool] {
 	mcs.LastKey = key
 	mcs.ExecutionCount++
 


### PR DESCRIPTION
## Context

Today the cache expiration with the Clickhouse pipeline leads to invalid cache when Clickhouse processing time is a bit slow and the current usage is requested before the new event is processed.

Flow:
- An event is consumed by the events processor and pushed to the `events-enriched` topic
- The events-processor deletes the usage cache for the matching charges and filters
- A current usage query is made and the result is cached
- Clickhouse consume the topic and and stores the new event in `events_enriched` / `events_enriched_expanded`

=> The cache value is false and will remain false until the end of the period or a new event is received for the same charge/filter

## Description

This PR change the logic of the caching expiration to move from a `delete` approach to an `expire` approach to give time to clickhouse to consume and process the new event.

A new caching approach will be required in the future to expired the cache only when the new event is effectively taken into account. But it's a larger topic that require way work