### PR TITLE
fix(docker): Fix Docker build of standalone container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Front
+front/node_modules
+
+# API
+api/.env

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,7 @@ COPY ./front/ .
 
 RUN apk add python3 build-base && \
   corepack enable && corepack prepare pnpm@latest --activate && \
-  rm -rf /app/node_modules && \
-  pnpm install && pnpm build && pnpm prune --prod
+  pnpm install && pnpm build
 
 # API Build
 FROM ruby:$RUBY_VERSION-slim AS api_build


### PR DESCRIPTION
## Context

When releasing v1.35.0, the Docker build failed with the following error:

```sh
134.8  ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY  Aborted removal of modules directory due to no TTY
134.8 
134.8 If you are running pnpm in CI, set the CI environment variable to "true".
------
Dockerfile:11
--------------------
  10 |     
  11 | >>> RUN apk add python3 build-base && \
  12 | >>>   corepack enable && corepack prepare pnpm@latest --activate && \
  13 | >>>   rm -rf /app/node_modules && \
  14 | >>>   pnpm install && pnpm build && pnpm prune --prod
  15 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c apk add python3 build-base &&   corepack enable && corepack prepare pnpm@latest --activate &&   rm -rf /app/node_modules &&   pnpm install && pnpm build && pnpm prune --prod" did not complete successfully: exit code: 1
```

This error seems to be related to the `pnpm` version update: https://github.com/pnpm/pnpm/issues/9966.

The suggested fix to add `CI=true` unfortunately doesn't work as it fails with:

```sh
50.97 . postinstall: > lago-design-system@0.0.0 build /app/packages/design-system
50.97 . postinstall: > rm -rf dist && tsc --build tsconfig.build.json && vite build
50.97 . postinstall: sh: tsc: not found
50.98 . postinstall: /app/packages/design-system:
50.98 . postinstall:  ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  lago-design-system@0.0.0 build: `rm -rf dist && tsc --build tsconfig.build.json && vite build`
50.98 . postinstall: spawn ENOENT
51.00 . postinstall:  ELIFECYCLE  Command failed with exit code 1.
51.01 . postinstall: Failed
51.02  ELIFECYCLE  Command failed with exit code 1.
------
Dockerfile:11
--------------------
  10 |     
  11 | >>> RUN apk add python3 build-base && \
  12 | >>>   corepack enable && corepack prepare pnpm@latest --activate && \
  13 | >>>   pnpm install && pnpm build && CI=true pnpm prune --prod
  14 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c apk add python3 build-base &&   corepack enable && corepack prepare pnpm@latest --activate &&   pnpm install && pnpm build && CI=true pnpm prune --prod" did not complete successfully: exit code: 1
```

One solution would be to revert to an older version but it would only be a temporary patch.

## Description

This fixes the issue by removing the `pnpm prune --prod` as the node modules are not copied into the final image (`COPY --from=front_build /app/dist /app/front`).

While testing this image locally, I noticed two issues:

1. The `front/node_modules` are not ignored via a `.dockerignore` which may cause `corepack prepare pnpm@latest --activate` to fail.
2. The `api/.env` are not ignored via a `.dockerignore` which causes the `api` to rely on a wrong `DATABASE_URL` env.

So these files/folders are now ignored via `.dockerignore`.