### PR TITLE
chore(db): Add `pghero` as part of the dev services

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,12 +32,14 @@ services:
     image: postgres:14.0-alpine
     container_name: lago_db_dev
     restart: unless-stopped
+    command: -c config_file=/etc/postgresql.conf
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-lago}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
       PGDATA: /data/postgres
       POSTGRES_MULTIPLE_DATABASES: lago,lago_test
     volumes:
+      - ./scripts/postgresql.conf:/etc/postgresql.conf
       - ./pg-init-scripts:/docker-entrypoint-initdb.d
       - postgres_data_dev:/data/postgres
     ports:
@@ -377,3 +379,28 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+
+  pghero:
+    image: ankane/pghero:latest
+    container_name: lago_pghero_dev
+    restart: unless-stopped
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-lago}:${POSTGRES_PASSWORD:-changeme}@db:5432/${POSTGRES_DB:-lago}
+    env_file:
+      - path: ./.env.development.default
+      - path: ./.env.development
+        required: false
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: wget -O /dev/null http://0.0.0.0:8080/health || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.pghero.rule=Host(`pghero.lago.dev`)"
+      - "traefik.http.routers.pghero.entrypoints=web,websecure"
+      - "traefik.http.routers.pghero.tls=true"
+      - "traefik.http.services.pghero.loadbalancer.server.port=8080"

--- a/scripts/postgresql.conf
+++ b/scripts/postgresql.conf
@@ -1,0 +1,75 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = '*'
+					# comma-separated list of addresses;
+					# defaults to 'localhost'; use '*' for all
+					# (change requires restart)
+max_connections = 100			# (change requires restart)
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = 128MB			# min 128kB
+					# (change requires restart)
+dynamic_shared_memory_type = posix	# the default is the first option
+					# supported by the operating system:
+					#   posix
+					#   sysv
+					#   windows
+					#   mmap
+					# (change requires restart)
+
+#------------------------------------------------------------------------------
+# WRITE-AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Checkpoints -
+
+max_wal_size = 1GB
+min_wal_size = 80MB
+
+#------------------------------------------------------------------------------
+# REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+log_timezone = 'UTC'
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Locale and Formatting -
+
+datestyle = 'iso, mdy'
+timezone = 'UTC'
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = 'en_US.utf8'			# locale for system error message
+					# strings
+lc_monetary = 'en_US.utf8'			# locale for monetary formatting
+lc_numeric = 'en_US.utf8'			# locale for number formatting
+lc_time = 'en_US.utf8'				# locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# pghero configuration
+shared_preload_libraries = 'pg_stat_statements'
+pg_stat_statements.track = all
+pg_stat_statements.max = 10000
+track_activity_query_size = 2048


### PR DESCRIPTION
## Context

We rely on [`pghero`](https://github.com/ankane/pghero/) on production. It can be useful to easily debug some performance issue, unused indexes, etc.

## Description

This adds `pghero` as a dev container.

In order to do so I had to update the `db` container to start PG with a specific config file. This file was copied from the actual container and updated to includes the necessary config for `pghero`.
