### PR TITLE
fix(docker): Fix Postgres init scripts

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,7 +40,7 @@ services:
       POSTGRES_MULTIPLE_DATABASES: lago,lago_test
     volumes:
       - ./scripts/postgresql.conf:/etc/postgresql.conf
-      - ./pg-init-scripts:/docker-entrypoint-initdb.d
+      - ./scripts/pg-init-scripts:/docker-entrypoint-initdb.d
       - postgres_data_dev:/data/postgres
     ports:
       - 5432:5432

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,7 +1,0 @@
-#! /bin/sh
-
-apt update
-apt install -y git curl
-curl -sL https://deb.nodesource.com/setup_20.x | sh -
-apt update
-apt install nodejs npm

--- a/scripts/pg-init-scripts/bootstrap.sh
+++ b/scripts/pg-init-scripts/bootstrap.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-apt update
-apt install -y git curl
-curl -sL https://deb.nodesource.com/setup_20.x | sh
-apt update
-apt install build-essential nodejs npm

--- a/scripts/pg-init-scripts/create-multiple-postgresql-databases.sh
+++ b/scripts/pg-init-scripts/create-multiple-postgresql-databases.sh
@@ -5,12 +5,23 @@ set -u
 
 function create_user_and_database() {
 	local database=$1
-	echo "  Creating user and database '$database'"
-	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
-	    CREATE USER $database;
-	    CREATE DATABASE $database;
-	    GRANT ALL PRIVILEGES ON DATABASE $database TO $database;
-EOSQL
+	echo "Creating user and database '$database'"
+
+	local db_exists=$(psql -U $POSTGRES_USER -tAc "SELECT 1 FROM pg_database WHERE datname='${database}'")
+
+	if [ "${db_exists}" != "1" ]; then
+		# Create the database
+		createdb -U $POSTGRES_USER ${database}
+		echo "Database ${database} created."
+	else
+		echo "Database ${database} already exists."
+	fi
+	local granted=$(psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -c "GRANT ALL PRIVILEGES ON DATABASE \"$database\" TO \"$POSTGRES_USER\";" 2>&1)
+	if [ "${granted}" == "GRANT" ]; then
+		echo "Granted privileges on database ${database} to user ${POSTGRES_USER}."
+	else
+		echo "Failed to grant privileges on database ${database} to user ${POSTGRES_USER}: ${granted}"
+	fi
 }
 
 if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then


### PR DESCRIPTION
## Context

https://github.com/getlago/lago/commit/2747b04ea90c8b87c0413f07bda117547176a52f introduced a PG init script which was meant to create the database. Due to a typo in the file path, it was never used by PG.

Later on, https://github.com/getlago/lago/commit/52ab3b351bac47980969978b98edea1aa637c587 introduced two `bootstrap.sh` which are not used.

## Description

This removes the `bootstrap.sh` and fixes the PG init script.

Note that the PG Docker image automatically creates a user and database based on the `POSTGRES_USER` and `POSTGRES_DB` variables. Since `POSTGRES_USER` is not defined, it will use `POSTGRES_USER` for both user and password:

```
/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/create-multiple-postgresql-databases.sh
Multiple database creation requested: lago,lago_test
Creating user and database 'lago'
Database lago already exists.
Granted privileges on database lago to user lago.
Creating user and database 'lago_test'
Database lago_test created.
Granted privileges on database lago_test to user lago.
Multiple databases created
```