### PR TITLE
chore(events-processor): Improve `events-processor` dev experience

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -249,9 +249,12 @@ services:
       context: ./events-processor
       dockerfile: Dockerfile.dev
     depends_on:
-      - db
-      - redpanda
-      - redis
+      db:
+        condition: service_healthy
+      redpanda:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     env_file:
       - path: ./.env.development.default
       - path: ./.env.development

--- a/events-processor/.air.toml
+++ b/events-processor/.air.toml
@@ -1,1 +1,9 @@
 
+[build]
+
+send_interrupt = true
+kill_delay = "10s"
+
+[log]
+
+time = true


### PR DESCRIPTION
## Context

The dev docker compose defines the dependencies of the `events-processor` but does not actually set the `condition`. Also the current `air` configuration doesn't allow for graceful shutdown.

## Description

This adds the `depends_on` conditions and also ensure that `air` will send an interrupt and wait 10s on shutdown before killing the app to allow for a graceful shutdown of the `events-processor`.