### PR TITLE
misc(events-processor): Extract records processing logic

### DIFF
--- a/events-processor/config/kafka/consumer.go
+++ b/events-processor/config/kafka/consumer.go
@@ -57,28 +57,32 @@ func (pc *PartitionConsumer) consume() {
 			return
 
 		case records := <-pc.records:
-			ctx := context.Background()
-			span := tracer.GetTracerSpan(ctx, "post_process", "Consumer.Consume")
-			recordsAttr := attribute.Int("records.length", len(records))
-			span.SetAttributes(recordsAttr)
-			defer span.End()
-
-			processedRecords := pc.processRecords(records)
-			commitableRecords := records
-
-			if len(processedRecords) != len(records) {
-				// Ensure we are not committing records that were not processed and can be re-consumed
-				record := findMaxCommitableRecord(processedRecords, records)
-				commitableRecords = []*kgo.Record{record}
-				return
-			}
-
-			err := pc.client.CommitRecords(ctx, commitableRecords...)
-			if err != nil {
-				pc.logger.Error(fmt.Sprintf("Error when committing offets to kafka. Error: %v topic: %s partition: %d offset: %d\n", err, pc.topic, pc.partition, records[len(records)-1].Offset+1))
-				utils.CaptureError(err)
-			}
+			pc.processRecordsAndCommit(records)
 		}
+	}
+}
+
+func (pc *PartitionConsumer) processRecordsAndCommit(records []*kgo.Record) {
+	ctx := context.Background()
+	span := tracer.GetTracerSpan(ctx, "post_process", "Consumer.Consume")
+	recordsAttr := attribute.Int("records.length", len(records))
+	span.SetAttributes(recordsAttr)
+	defer span.End()
+
+	processedRecords := pc.processRecords(records)
+	commitableRecords := records
+
+	if len(processedRecords) != len(records) {
+		// Ensure we are not committing records that were not processed and can be re-consumed
+		record := findMaxCommitableRecord(processedRecords, records)
+		commitableRecords = []*kgo.Record{record}
+		return
+	}
+
+	err := pc.client.CommitRecords(ctx, commitableRecords...)
+	if err != nil {
+		pc.logger.Error(fmt.Sprintf("Error when committing offets to kafka. Error: %v topic: %s partition: %d offset: %d\n", err, pc.topic, pc.partition, records[len(records)-1].Offset+1))
+		utils.CaptureError(err)
 	}
 }
 
@@ -122,23 +126,28 @@ func (cg *ConsumerGroup) lost(_ context.Context, _ *kgo.Client, lost map[string]
 
 func (cg *ConsumerGroup) poll() {
 	for {
-		fetches := cg.client.PollRecords(context.Background(), 10000)
-		if fetches.IsClientClosed() {
-			cg.logger.Info("client closed")
-			return
-		}
-
-		fetches.EachError(func(_ string, _ int32, err error) {
-			panic(err)
-		})
-
-		fetches.EachPartition(func(p kgo.FetchTopicPartition) {
-			tp := TopicPartition{p.Topic, p.Partition}
-			cg.consumers[tp].records <- p.Records
-		})
-
-		cg.client.AllowRebalance()
+		// NOTE: Gracefull shutdown handling will be plugged in here
+		cg.pollRecords()
 	}
+}
+
+func (cg *ConsumerGroup) pollRecords() {
+	fetches := cg.client.PollRecords(context.Background(), 10000)
+	if fetches.IsClientClosed() {
+		cg.logger.Info("client closed")
+		return
+	}
+
+	fetches.EachError(func(_ string, _ int32, err error) {
+		panic(err)
+	})
+
+	fetches.EachPartition(func(p kgo.FetchTopicPartition) {
+		tp := TopicPartition{p.Topic, p.Partition}
+		cg.consumers[tp].records <- p.Records
+	})
+
+	cg.client.AllowRebalance()
 }
 
 func NewConsumerGroup(serverConfig ServerConfig, cfg *ConsumerGroupConfig) (*ConsumerGroup, error) {


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic, it follows https://github.com/getlago/lago/pull/606

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR is the last preparatory PR before https://github.com/getlago/lago/pull/608. The goal is to extract the record processing logic into simpler function that will make it easier to add graceful shutdown