### PR TITLE
fix(events-processor): Avoid joining on customer table

### DIFF
--- a/events-processor/models/subscriptions.go
+++ b/events-processor/models/subscriptions.go
@@ -23,7 +23,7 @@ func (store *ApiStore) FetchSubscription(organizationID string, externalID strin
 	var sub Subscription
 
 	var conditions = `
-		customers.organization_id = ?
+		subscriptions.organization_id = ?
 		AND subscriptions.external_id = ?
 		AND date_trunc('millisecond', subscriptions.started_at::timestamp) <= ?::timestamp
 		AND (subscriptions.terminated_at IS NULL OR date_trunc('millisecond', subscriptions.terminated_at::timestamp) >= ?)
@@ -31,7 +31,6 @@ func (store *ApiStore) FetchSubscription(organizationID string, externalID strin
 	result := store.db.Connection.
 		Table("subscriptions").
 		Unscoped().
-		Joins("INNER JOIN customers ON customers.id = subscriptions.customer_id").
 		Where(conditions, organizationID, externalID, timestamp, timestamp).
 		Order("terminated_at DESC NULLS FIRST, started_at DESC").
 		Limit(1).

--- a/events-processor/models/subscriptions_test.go
+++ b/events-processor/models/subscriptions_test.go
@@ -12,11 +12,9 @@ import (
 )
 
 var fetchSubscriptionQuery = regexp.QuoteMeta(`
-	SELECT
-	"subscriptions"."id","subscriptions"."external_id","subscriptions"."plan_id","subscriptions"."created_at","subscriptions"."updated_at","subscriptions"."started_at","subscriptions"."terminated_at"
+	SELECT *
 	FROM "subscriptions"
-		INNER JOIN customers ON customers.id = subscriptions.customer_id
-	WHERE customers.organization_id = $1
+	WHERE subscriptions.organization_id = $1
 		AND subscriptions.external_id = $2
 		AND date_trunc('millisecond', subscriptions.started_at::timestamp) <= $3::timestamp
 		AND (subscriptions.terminated_at IS NULL OR date_trunc('millisecond', subscriptions.terminated_at::timestamp) >= $4)


### PR DESCRIPTION
## Description

This PR removes the join on customers table in the database query used to fetch the subscription matching the event timestamp. This filter on organization_id is changed from `customers.organization_id` to `subscriptions.organization_id`.

The `organization_id` column was added on the table subscription, but the change was not reflected on the events-processor