### PR TITLE
misc(events-processor): Improve env variable management

### DIFF
--- a/events-processor/processors/main_processor.go
+++ b/events-processor/processors/main_processor.go
@@ -134,7 +134,7 @@ func StartProcessingEvents(ctx context.Context, config *Config) {
 
 	kafkaConfig = kafka.ServerConfig{
 		ScramAlgorithm: os.Getenv(envLagoKafkaScramAlgorithm),
-		TLS:            os.Getenv(envLagoKafkaTLS) == "true",
+		TLS:            utils.GetEnvAsBool(envLagoKafkaTLS, false),
 		Servers:        serverBrokers,
 		UseTelemetry:   config.UseTelemetry,
 		UserName:       os.Getenv(envLagoKafkaUsername),

--- a/events-processor/utils/env.go
+++ b/events-processor/utils/env.go
@@ -41,3 +41,12 @@ func GetEnvAsBool(key string, defaultValue bool) bool {
 
 	return boolValue
 }
+
+func GetEnvOrDefault(key string, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+
+	return value
+}

--- a/events-processor/utils/env_test.go
+++ b/events-processor/utils/env_test.go
@@ -72,3 +72,16 @@ func TestGetEnvAsBool(t *testing.T) {
 		assert.False(t, value)
 	})
 }
+
+func TestGetEnvOrDefault(t *testing.T) {
+	t.Run("should return environment variable value when set", func(t *testing.T) {
+		t.Setenv("TEST_DEFAULT_ENV", "test_value")
+		value := GetEnvOrDefault("TEST_DEFAULT_ENV", "default_value")
+		assert.Equal(t, "test_value", value)
+	})
+
+	t.Run("should return default value when environment variable is not set", func(t *testing.T) {
+		value := GetEnvOrDefault("NON_EXISTENT_DEFAULT_ENV", "default_value")
+		assert.Equal(t, "default_value", value)
+	})
+}


### PR DESCRIPTION
This PR adds a new `utils.GetEnvOrDefault` used to lookup for an env variable or using a fallback if not defined. It will be used on a coming PR that is adding the setup for Datadog.

An other small improvement around env variable is also being made 