### PR TITLE
misc(events-processor): Cleaning up result in main processor

### DIFF
--- a/events-processor/utils/error_tracker.go
+++ b/events-processor/utils/error_tracker.go
@@ -1,6 +1,10 @@
 package utils
 
-import "github.com/getsentry/sentry-go"
+import (
+	"log/slog"
+
+	"github.com/getsentry/sentry-go"
+)
 
 func CaptureErrorResult(errResult AnyResult) {
 	CaptureErrorResultWithExtra(errResult, "", nil)
@@ -21,4 +25,10 @@ func CaptureErrorResultWithExtra(errResult AnyResult, extraKey string, extraValu
 
 func CaptureError(err error) {
 	sentry.CaptureException(err)
+}
+
+func LogAndPanic(logger *slog.Logger, err error, message string) {
+	logger.Error(message, slog.String("error", err.Error()))
+	CaptureError(err)
+	panic(err.Error())
 }


### PR DESCRIPTION
## Description

This PR is refactoring a bit the main event processor to avoid relying on `utils.Result` when it's not mandatory.
It also add a new `utils.LogAndPanic` to DRY a bit the code of the initialization phase