### PR TITLE
misc(event-processor): Refactor kafka loggers to use new tracing provider logic

### DIFF
--- a/events-processor/config/tracing/datadog_tracer.go
+++ b/events-processor/config/tracing/datadog_tracer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/twmb/franz-go/pkg/kgo"
 	ddtracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
@@ -88,6 +89,11 @@ func (p *DatadogTracerProvider) Stop() {
 
 func (p *DatadogTracerProvider) InitTracer(serviceName string) Tracer {
 	return NewDatadogTracer(serviceName)
+}
+
+// Hooks returns the kgo hooks for Datadog instrumentation
+func (p *DatadogTracerProvider) GetKafkaHooks() []kgo.Hook {
+	return []kgo.Hook{} // TODO(datadog): implement
 }
 
 func NewDatadogTracerProvider(logger *slog.Logger, opts TracerProviderOptions) *DatadogTracerProvider {

--- a/events-processor/config/tracing/empty_tracer.go
+++ b/events-processor/config/tracing/empty_tracer.go
@@ -2,6 +2,8 @@ package tracing
 
 import (
 	"context"
+
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 // EmptySpan implements the Span interface.
@@ -40,3 +42,5 @@ func (p *EmptyTracerProvider) Stop() {}
 func (p *EmptyTracerProvider) InitTracer(serviceName string) Tracer {
 	return NewEmptyTracer()
 }
+
+func (p *EmptyTracerProvider) GetKafkaHooks() []kgo.Hook { return []kgo.Hook{} }

--- a/events-processor/config/tracing/tracing.go
+++ b/events-processor/config/tracing/tracing.go
@@ -2,6 +2,8 @@ package tracing
 
 import (
 	"context"
+
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 // Generic tracing span interface
@@ -56,6 +58,9 @@ type TracerProvider interface {
 
 	// InitTracer initializes a new tracer for the provider with the given service name.
 	InitTracer(serviceName string) Tracer
+
+	// GetKafkaHooks returns the Kafka hooks for the provider.
+	GetKafkaHooks() []kgo.Hook
 }
 
 // TracerProviderOptions is a struct that holds the options for configuring a tracer provider.

--- a/events-processor/main.go
+++ b/events-processor/main.go
@@ -50,8 +50,8 @@ func main() {
 
 	// start processing events & loop forever
 	processors.StartProcessingEvents(ctx, &processors.Config{
-		Logger:       logger,
-		UseTelemetry: tracerProvider.GetOptions().TracingProvider == tracing.OTelProvider, // TODO: Check for datadog
+		Logger:         logger,
+		TracerProvider: tracerProvider,
 	})
 }
 

--- a/events-processor/processors/main_processor.go
+++ b/events-processor/processors/main_processor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getlago/lago/events-processor/config/database"
 	"github.com/getlago/lago/events-processor/config/kafka"
 	"github.com/getlago/lago/events-processor/config/redis"
+	"github.com/getlago/lago/events-processor/config/tracing"
 	"github.com/getlago/lago/events-processor/models"
 	"github.com/getlago/lago/events-processor/processors/events_processor"
 	"github.com/getlago/lago/events-processor/utils"
@@ -48,8 +49,8 @@ const (
 )
 
 type Config struct {
-	Logger       *slog.Logger
-	UseTelemetry bool
+	Logger         *slog.Logger
+	TracerProvider tracing.TracerProvider
 }
 
 func initProducer(ctx context.Context, topicEnv string) (*kafka.Producer, error) {
@@ -135,7 +136,7 @@ func StartProcessingEvents(ctx context.Context, config *Config) {
 		ScramAlgorithm: os.Getenv(envLagoKafkaScramAlgorithm),
 		TLS:            utils.GetEnvAsBool(envLagoKafkaTLS, false),
 		Servers:        serverBrokers,
-		UseTelemetry:   config.UseTelemetry,
+		TracerProvider: config.TracerProvider,
 		UserName:       os.Getenv(envLagoKafkaUsername),
 		Password:       os.Getenv(envLagoKafkaPassword),
 	}


### PR DESCRIPTION
## Description

This PR follows https://github.com/getlago/lago/pull/633

The main goal is to refactor the monitoring approach of the Kafka consumer and producer that relies on kotel. The initialization phase is not moved into the previously added `tracing.TracerProvider` logic to re-use the existing setup. It will also allow us to add the kafka tracing for datadog in a later PR.