### PR TITLE
fix(kafka): Add missing topic in dev env

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -358,6 +358,7 @@ services:
       - events-raw
       - events_enriched
       - events_charged_in_advance
+      - events_enriched_expanded
       - events_dead_letter
       - activity_logs
       - api_logs


### PR DESCRIPTION
This PR adds the missing `events_enriched_expanded` kafka topic in dev environment