### PR TITLE
bug: make sure git clone get tags updated

### DIFF
--- a/events-processor/Dockerfile
+++ b/events-processor/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.85 AS rust-build
 
-RUN git clone https://github.com/getlago/lago-expression/
+RUN git clone --tags https://github.com/getlago/lago-expression/
 WORKDIR /lago-expression/expression-go
 RUN git checkout v0.2.0 && cargo build --release
 

--- a/events-processor/Dockerfile.dev
+++ b/events-processor/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM rust:1.85 AS rust-build
 
-RUN git clone https://github.com/getlago/lago-expression/
+RUN git clone --tags https://github.com/getlago/lago-expression/
 WORKDIR /lago-expression/expression-go
 RUN git checkout v0.2.0 && cargo build --release
 


### PR DESCRIPTION
We clone the `lago-expression` during event processor build.

We also need to force the tags fetch, in case a new version have been release. Otherwise the cached version list will make the build fail 