### PR TITLE
chore(env): Disable webhook retry in dev

### DIFF
--- a/.env.development.default
+++ b/.env.development.default
@@ -36,6 +36,7 @@ LAGO_REDIS_STORE_DB=1
 # Misc
 LAGO_FROM_EMAIL=noreply@getlago.com
 LAGO_PARALLEL_THREADS_COUNT=4
+LAGO_WEBHOOK_ATTEMPTS=1
 
 # Use dedicated services to process certain queues
 # If you enable one, make sure the related service is started


### PR DESCRIPTION
Locally, we typically don't run any service to receive the webhook so they always fail. No need to retry 3 times, we know they are going to fail! My main reason to do this is to keep the logs in the terminal a little bit lighter.