### PR TITLE
misc(redis): Add doc for new env variable

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -402,6 +402,8 @@ Lago uses three separate Redis instances for different purposes:
 **Configuration**:
 - `LAGO_REDIS_STORE_URL` - Connection URI
 - `LAGO_REDIS_STORE_PASSWORD` - Password (separate for security)
+- `LAGO_REDIS_STORE_SSL` - Use SSL to access Redis. It will be used only if `LAGO_REDIS_STORE_URL` does not contains the `rediss://` prefix
+- `LAGO_REDIS_STORE_DISABLE_SSL_VERIFY` - Turn off SSL certificate verification
 
 **Purpose**: Dedicated storage for event-related data and event processing workflows
 


### PR DESCRIPTION
This PR is related to https://github.com/getlago/lago-api/pull/4855.

The goal is to document two new environment variables that have been added to manage the REDIS_STORE connection:
- `LAGO_REDIS_STORE_SSL` to force the use of  SSL connection. Used only in absence of the `rediss://` prefix in the `LAGO_REDIS_STORE_URL` variable.
- `LAGO_REDIS_STORE_DISABLE_SSL_VERIFY` - Turn off SSL certificate verification