### PR TITLE
misc: Bump version to 7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 x-postgres-image: &postgres-image
   image: postgres:14-alpine
 x-redis-image: &redis-image
-  image: redis:6-alpine
+  image: redis:7-alpine
 x-backend-image: &backend-image
   image: getlago/api:v1.39.0
 x-frontend-image: &frontend-image


### PR DESCRIPTION
This PR bumps redis version in production docker-compose.yaml file from 6 to 7 as redis 6 is not officially supported anymore.