### PR TITLE
fix: Update broken links of self-hosted guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,12 @@ Your API Key can be found directly in the UI:
 ### Analytics and tracking
 Please note that Lago, by default, tracks basic actions performed on your self-hosted instance. If you do not disable tracking, you may receive specific communications or product updates. However, rest assured that Lago will not collect any personal information about your customers or financial information about your invoices.
 
-If you would like to know more about Lago's analytics or remove the entire tracking, please refer to [this page](https://doc.getlago.com/guide/self-hosted/tracking-analytics) for comprehensive information.
+If you would like to know more about Lago's analytics or remove the entire tracking, please refer to [this page](https://doc.getlago.com/guide/lago-self-hosted/tracking-analytics) for comprehensive information.
 
 ### Version, environment variables and components
 Docker images are always updated to the last stable version in the docker-compose.yml file. You can use a different tag if needed by checking the releases list.
 
-Lago uses the following environment variables to configure the components of the application. You can override them to customise your setup. Take a closer look are our [documentation](https://doc.getlago.com/docs/guide/self-hosting/docker#configuration).
+Lago uses the following environment variables to configure the components of the application. You can override them to customise your setup. Take a closer look are our [documentation](https://doc.getlago.com/guide/lago-self-hosted/docker#configuration).
 
 ## ☁️ Use our cloud-based product
 Contact our team at hello@getlago.com to get started with Lago Cloud. More information on [our website](https://www.getlago.com/pricing).

--- a/docs/dev_environment.md
+++ b/docs/dev_environment.md
@@ -2,7 +2,7 @@
 
 Welcome to the Lago development environment setup guide!
 
-This documentation is designed for contributors who want to work on Lago. If you're just looking to try Lago locally, please refer to the [Lago public documentation](https://doc.getlago.com/docs/guide/self-hosting/docker) for a simpler setup.
+This documentation is designed for contributors who want to work on Lago. If you're just looking to try Lago locally, please refer to the [Lago public documentation](https://doc.getlago.com/guide/lago-self-hosted/docker) for a simpler setup.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Pull Request

This small PR fixes the broken links of self-hosted guides in documentation