### PR TITLE
chore(redis): Allow to test Redis with password

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,12 +57,17 @@ services:
     image: redis:7-alpine
     container_name: lago_redis_dev
     restart: unless-stopped
+    command: ["sh", "-c", "redis-server --requirepass \"$$REDIS_PASSWORD\""]
+    env_file:
+      - path: ./.env.development.default
+      - path: ./.env.development
+        required: false
     volumes:
       - redis_data_dev:/data
     ports:
       - 6379:6379
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD-SHELL", "redis-cli $${REDIS_PASSWORD:+-a \"$$REDIS_PASSWORD\"} ping"]
       interval: 10s
       timeout: 3s
       retries: 3
@@ -496,15 +501,19 @@ services:
       - "traefik.http.services.pghero.loadbalancer.server.port=8080"
 
   redis-replica:
-    command: ["redis-server", "--replicaof", "redis", "6379"]
+    command: ["sh", "-c", "redis-server --replicaof redis 6379 --requirepass \"$$REDIS_PASSWORD\" --masterauth \"$$REDIS_PASSWORD\""]
     container_name: lago_redis_replica_dev
     depends_on:
       redis:
         condition: service_healthy
+    env_file:
+      - path: ./.env.development.default
+      - path: ./.env.development
+        required: false
     healthcheck:
       interval: 10s
       retries: 3
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD-SHELL", "redis-cli $${REDIS_PASSWORD:+-a \"$$REDIS_PASSWORD\"} ping"]
       timeout: 3s
     image: redis:7-alpine
     profiles:
@@ -515,7 +524,10 @@ services:
 
   redis-sentinel-1: &redis-sentinel
   # Sentinel requires write to the configuration file so we cannot use volume for it, we need to copy it to the container and then run sentinel with the copied file.
-    command: sh -c 'cp /tmp/sentinel.conf /etc/sentinel.conf && redis-sentinel /etc/sentinel.conf'
+    command: >-
+      sh -c 'cp /tmp/sentinel.conf /etc/sentinel.conf &&
+      if [ -n "$$REDIS_PASSWORD" ]; then echo "sentinel auth-pass master $$REDIS_PASSWORD" >> /etc/sentinel.conf; fi &&
+      redis-sentinel /etc/sentinel.conf'
     configs:
       - source: redis-sentinel-conf
         target: /tmp/sentinel.conf
@@ -525,6 +537,10 @@ services:
         condition: service_healthy
       redis-replica:
         condition: service_healthy
+    env_file:
+      - path: ./.env.development.default
+      - path: ./.env.development
+        required: false
     healthcheck:
       interval: 10s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,7 +57,7 @@ services:
     image: redis:7-alpine
     container_name: lago_redis_dev
     restart: unless-stopped
-    command: ["sh", "-c", "redis-server --requirepass \"$$REDIS_PASSWORD\""]
+    command: ["sh", "-c", "redis-server $${REDIS_PASSWORD:+--requirepass \"$$REDIS_PASSWORD\"}"]
     env_file:
       - path: ./.env.development.default
       - path: ./.env.development
@@ -501,7 +501,7 @@ services:
       - "traefik.http.services.pghero.loadbalancer.server.port=8080"
 
   redis-replica:
-    command: ["sh", "-c", "redis-server --replicaof redis 6379 --requirepass \"$$REDIS_PASSWORD\" --masterauth \"$$REDIS_PASSWORD\""]
+    command: ["sh", "-c", "redis-server --replicaof redis 6379 $${REDIS_PASSWORD:+--requirepass \"$$REDIS_PASSWORD\" --masterauth \"$$REDIS_PASSWORD\"}"]
     container_name: lago_redis_replica_dev
     depends_on:
       redis:


### PR DESCRIPTION
## Context

The `api` allows to specify the Redis password for Sidekiq, cache and store but there's no easy way to handle this in a development environment.

## Describe

This allows us to specify the `REDIS_PASSWORD` in `.env.development` so that it's taken into account by Redis, its replica and its sentinels.

This requires https://github.com/getlago/lago-api/pull/5068.

This was tested thoroughly with and without Sentinel:

* With password:

    ```
    ⋊> lago exec redis redis-cli -n 0 -p 6379 --pass password SET test value
    OK
    ⋊> lago exec redis redis-cli -n 0 -p 6379 SET test value
    (error) NOAUTH Authentication required.
    ⋊> lago exec api bundle exec rails runner 'Sidekiq.redis { |r| r.set("test", "value") }; puts Sidekiq.redis { |r| r.get("test") }'
    value
    ⋊> lago exec api bundle exec rails runner 'Rails.cache.write("test", "value"); puts Rails.cache.read("test")'
    value
    ⋊> lago exec api bundle exec rails runner 'r = Subscriptions::ConsumeSubscriptionRefreshedQueueService.new.send((:redis_client));r.set("test", "value"); puts r.get("test")'
    value
    ```

* With password (and Sentinel):

    ```
    ⋊> lago exec redis redis-cli -n 0 -p 6379 --pass password SET test value
    OK
    ⋊> lago exec redis redis-cli -n 0 -p 6379 SET test value
    (error) NOAUTH Authentication required.
    ⋊> lago exec redis-sentinel-1 redis-cli -n 0 -p 26379 sentinel master master | head -n 10
    name
    master
    ip
    172.24.0.7
    port
    6379
    runid
    8a7872bf9f08733f2440dee89d3841cdf182940a
    flags
    master
    ⋊> lago exec api bundle exec rails runner 'Sidekiq.redis { |r| r.set("test", "value") }; puts Sidekiq.redis { |r| r.get("test") }' # {"ts":"2026-02-18T15:48:14.644Z","pid":110,"tid":"2mu","lvl":"INFO","msg":"Sidekiq 7.3.7 connecting to Redis with options {size: 10, pool_name: \"internal\", url: \"redis://redis:6379\", sentinels: [{host: \"redis-sentinel-1\", port: 26379}, {host: \"redis-sentinel-2\", port: 26379}, {host: \"redis-sentinel-3\", port: 26379}], role: :master, name: \"master\", password: \"REDACTED\", pool_timeout: 5, timeout: 5}"}
    value
    ⋊> lago exec api bundle exec rails runner 'Rails.cache.write("test", "value"); puts Rails.cache.read("test")'
    value
    ⋊> lago exec api bundle exec rails runner 'r = Subscriptions::ConsumeSubscriptionRefreshedQueueService.new.send((:redis_client));r.set("test", "value"); puts r.get("test")'
    value
    ⋊> lago down
    ⋊> lago exec redis redis-cli -n 0 -p 6379 --pass password SET test value
    service "redis" is not running
    ⋊> lago exec redis redis-cli -n 0 -p 6379 SET test value
    service "redis" is not running
    ⋊> lago exec redis-replica redis-cli -n 0 -p 6379 --pass password SET test value
    OK
    ⋊> lago exec redis-replica redis-cli -n 0 -p 6379 SET test value
    (error) NOAUTH Authentication required.
    ⋊> lago exec api bundle exec rails runner 'Sidekiq.redis { |r| r.set("test", "value") }; puts Sidekiq.redis { |r| r.get("test") }'
    value
    ⋊> lago exec api bundle exec rails runner 'Rails.cache.write("test", "value"); puts Rails.cache.read("test")'
    /usr/local/lib/ruby/3.4.0/socket.rb:891:in 'block in Socket.tcp_with_fast_fallback': getaddrinfo: Name or service not known (redis://redis:6379/1) (Redis::CannotConnectError)
    ⋊> lago exec api bundle exec rails runner 'r = Subscriptions::ConsumeSubscriptionRefreshedQueueService.new.send((:redis_client));r.set("test", "value"); puts r.get("test")'
    /usr/local/lib/ruby/3.4.0/socket.rb:891:in 'block in Socket.tcp_with_fast_fallback': getaddrinfo: Name or service not known (redis://redis:6379/1) (Redis::CannotConnectError)
    ```


* Without password:

    ```sh
    ⋊> lago exec redis redis-cli -n 0 -p 6379 SET test value
    OK
    ⋊> lago exec api bundle exec rails runner 'Sidekiq.redis { |r| r.set("test", "value") }; puts Sidekiq.redis { |r| r.get("test") }'
    value
    ⋊> lago exec api bundle exec rails runner 'Rails.cache.write("test", "value"); puts Rails.cache.read("test")'
    value
    ⋊> lago exec api bundle exec rails runner 'r = Subscriptions::ConsumeSubscriptionRefreshedQueueService.new.send((:redis_client));r.set("test", "value"); puts r.get("test")'
    value
    ```

