### PR TITLE
feat(events-processor): Enrich event with target wallet code

### DIFF
--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -8,6 +8,7 @@ import (
 )
 
 const HTTP_RUBY string = "http_ruby"
+const TARGET_WALLET_CODE string = "target_wallet_code"
 
 type Event struct {
 	OrganizationID          string           `json:"organization_id"`
@@ -51,6 +52,7 @@ type EnrichedEvent struct {
 	ChargeFilterID          *string           `json:"charge_filter_id"`
 	ChargeFilterUpdatedAt   *time.Time        `json:"charge_filter_updated_at"`
 	GroupedBy               map[string]string `json:"grouped_by"`
+	TargetWalletCode        *string           `json:"target_wallet_code"`
 }
 
 type FailedEvent struct {

--- a/events-processor/models/flat_filters.go
+++ b/events-processor/models/flat_filters.go
@@ -94,6 +94,7 @@ type FlatFilter struct {
 	Filters               *FlatFilterValues `gorm:"type:jsonb"`
 	PricingGroupKeys      PricingGroupKeys  `gorm:"type:jsonb"`
 	PayInAdvance          bool              `gorm:"type:boolean"`
+	AcceptsTargetWallet   bool              `gorm:"type:boolean"`
 }
 
 func (store *ApiStore) FetchFlatFilters(planID string, billableMetricCode string) utils.Result[[]FlatFilter] {
@@ -149,12 +150,13 @@ func (ff *FlatFilter) IsMatchingEvent(event *EnrichedEvent) utils.Result[bool] {
 
 func (ff *FlatFilter) ToDefaultFilter() *FlatFilter {
 	defaultFilter := &FlatFilter{
-		OrganizationID:     ff.OrganizationID,
-		BillableMetricCode: ff.BillableMetricCode,
-		PlanID:             ff.PlanID,
-		ChargeID:           ff.ChargeID,
-		ChargeUpdatedAt:    ff.ChargeUpdatedAt,
-		PayInAdvance:       ff.PayInAdvance,
+		OrganizationID:      ff.OrganizationID,
+		BillableMetricCode:  ff.BillableMetricCode,
+		PlanID:              ff.PlanID,
+		ChargeID:            ff.ChargeID,
+		ChargeUpdatedAt:     ff.ChargeUpdatedAt,
+		PayInAdvance:        ff.PayInAdvance,
+		AcceptsTargetWallet: ff.AcceptsTargetWallet,
 	}
 
 	return defaultFilter

--- a/events-processor/models/flat_filters_test.go
+++ b/events-processor/models/flat_filters_test.go
@@ -35,9 +35,33 @@ func TestFetchFlatFilters(t *testing.T) {
 		pricingGroupKeysJSON, _ := json.Marshal(pricingGroupKeys)
 
 		// Define expected rows and columns
-		columns := []string{"organization_id", "billable_metric_code", "plan_id", "charge_id", "charge_updated_at", "charge_filter_id", "charge_filter_updated_at", "filters", "pricing_group_keys"}
+		columns := []string{
+			"organization_id",
+			"billable_metric_code",
+			"plan_id",
+			"charge_id",
+			"charge_updated_at",
+			"charge_filter_id",
+			"charge_filter_updated_at",
+			"filters",
+			"pricing_group_keys",
+			"pay_in_advance",
+			"accepts_target_wallet",
+		}
 		rows := sqlmock.NewRows(columns).
-			AddRow("1a901a90-1a90-1a90-1a90-1a901a901a90", code, planID, "1a901a90-1a90-1a90-1a90-1a901a901a90", now, "1a901a90-1a90-1a90-1a90-1a901a901a90", now, filtersJSON, pricingGroupKeysJSON)
+			AddRow(
+				"1a901a90-1a90-1a90-1a90-1a901a901a90",
+				code,
+				planID,
+				"1a901a90-1a90-1a90-1a90-1a901a901a90",
+				now,
+				"1a901a90-1a90-1a90-1a90-1a901a901a90",
+				now,
+				filtersJSON,
+				pricingGroupKeysJSON,
+				true,
+				true,
+			)
 
 		// Expect the query
 		mock.ExpectQuery(fetchFiltersQuery).
@@ -58,6 +82,8 @@ func TestFetchFlatFilters(t *testing.T) {
 		assert.Equal(t, filters, actualFilters)
 
 		assert.Equal(t, pricingGroupKeys, []string(flatFilter.PricingGroupKeys))
+		assert.True(t, flatFilter.PayInAdvance)
+		assert.True(t, flatFilter.AcceptsTargetWallet)
 	})
 
 	t.Run("should return an empty result when not found", func(t *testing.T) {
@@ -69,7 +95,19 @@ func TestFetchFlatFilters(t *testing.T) {
 		planID := "1a901a90-1a90-1a90-1a90-1a901a901a90"
 
 		// Define expected rows and columns
-		columns := []string{"organization_id", "billable_metric_code", "plan_id", "charge_id", "charge_updated_at", "charge_filter_id", "charge_filter_updated_at", "filters"}
+		columns := []string{
+			"organization_id",
+			"billable_metric_code",
+			"plan_id",
+			"charge_id",
+			"charge_updated_at",
+			"charge_filter_id",
+			"charge_filter_updated_at",
+			"filters",
+			"pricing_group_keys",
+			"pay_in_advance",
+			"accepts_target_wallet",
+		}
 		rows := sqlmock.NewRows(columns)
 
 		// Expect the query
@@ -196,6 +234,8 @@ func TestToDefaultFilter(t *testing.T) {
 				"scheme":         {"visa", "mastercard"},
 				"payment_method": {"debit"},
 			},
+			PayInAdvance:        true,
+			AcceptsTargetWallet: false,
 		}
 
 		filter := flatFilter.ToDefaultFilter()
@@ -207,6 +247,8 @@ func TestToDefaultFilter(t *testing.T) {
 		assert.Nil(t, filter.ChargeFilterID)
 		assert.Nil(t, filter.ChargeFilterUpdatedAt)
 		assert.Nil(t, filter.Filters)
+		assert.True(t, filter.PayInAdvance)
+		assert.False(t, filter.AcceptsTargetWallet)
 	})
 }
 

--- a/events-processor/processors/events_processor/enrichment_service.go
+++ b/events-processor/processors/events_processor/enrichment_service.go
@@ -159,11 +159,22 @@ func (s *EventEnrichmentService) enrichWithChargeInfo(enrichedEvent *models.Enri
 }
 
 func enrichWithPricingGroupKeys(event *models.EnrichedEvent) {
-	if event.FlatFilter == nil || event.FlatFilter.PricingGroupKeys == nil {
+	if event.FlatFilter == nil {
 		return
 	}
 
-	for _, key := range event.FlatFilter.PricingGroupKeys {
-		event.GroupedBy[key] = fmt.Sprintf("%v", event.Properties[key])
+	if event.FlatFilter.PricingGroupKeys != nil {
+		for _, key := range event.FlatFilter.PricingGroupKeys {
+			event.GroupedBy[key] = fmt.Sprintf("%v", event.Properties[key])
+		}
+	}
+
+	// Enrich with target wallet code when applicable
+	if event.FlatFilter.AcceptsTargetWallet {
+		if raw, ok := event.Properties[models.TARGET_WALLET_CODE]; ok && raw != nil {
+			formatted := fmt.Sprintf("%v", raw)
+			event.GroupedBy[models.TARGET_WALLET_CODE] = formatted
+			event.TargetWalletCode = utils.StringPtr(formatted)
+		}
 	}
 }

--- a/events-processor/processors/events_processor/processor_test.go
+++ b/events-processor/processors/events_processor/processor_test.go
@@ -108,6 +108,7 @@ func mockFlatFiltersLookup(mock *tests.MockedStore, filters []*models.FlatFilter
 		"charge_filter_updated_at",
 		"filters",
 		"pricing_group_keys",
+		"accepts_target_wallet",
 	}
 
 	rows := sqlmock.NewRows(columns)
@@ -124,6 +125,7 @@ func mockFlatFiltersLookup(mock *tests.MockedStore, filters []*models.FlatFilter
 			filter.ChargeFilterUpdatedAt,
 			filter.Filters,
 			filter.PricingGroupKeys,
+			filter.AcceptsTargetWallet,
 		)
 	}
 


### PR DESCRIPTION
##Description

This PR follows https://github.com/getlago/lago-api/pull/5075

It updates the event enrichment pipeline to fill the `GroupedBy` and new `TargetWalletCode` attributes when the `FlatFilter.AcceptsTargetWallet` attribute is set to true.