### PR TITLE
ci: add tag-triggered release pipeline for docker images

### DIFF
--- a/.github/workflows/docker-build-multi-arch.yaml
+++ b/.github/workflows/docker-build-multi-arch.yaml
@@ -52,7 +52,7 @@ on:
         default: ''
 
       cache-type:
-        description: 'Cache type (gha or registry)'
+        description: 'Cache type (gha, registry, or disabled)'
         required: false
         type: string
         default: 'registry'
@@ -263,9 +263,8 @@ jobs:
           build-args: ${{ inputs.build-args }}
           secrets: ${{ secrets.build-secrets }}
           outputs: type=image,name=${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=true
-          # Registry cache - persistent and shared across runners
-          cache-from: type=registry,ref=${{ inputs.image-name }}:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=${{ inputs.image-name }}:buildcache-${{ matrix.arch }},mode=max
+          cache-from: ${{ inputs.cache-type != 'disabled' && format('type=registry,ref={0}:buildcache-{1}', inputs.image-name, matrix.arch) || '' }}
+          cache-to: ${{ inputs.cache-type != 'disabled' && format('type=registry,ref={0}:buildcache-{1},mode=max', inputs.image-name, matrix.arch) || '' }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Export digest

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,42 @@
+name: Release Images
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  api:
+    uses: ./.github/workflows/docker-build-multi-arch.yaml
+    with:
+      image-name: ghcr.io/getlago/api
+      registry: ghcr
+      cache-type: disabled
+      repository: getlago/lago-api
+      platforms: amd64
+      ref: ${{ github.ref }}
+    secrets:
+      repository-token: ${{ secrets.GH_TOKEN }}
+
+  front:
+    uses: ./.github/workflows/docker-build-multi-arch.yaml
+    with:
+      image-name: ghcr.io/getlago/front
+      registry: ghcr
+      cache-type: disabled
+      platforms: amd64
+      repository: getlago/lago-front
+      ref: ${{ github.ref }}
+    secrets:
+      repository-token: ${{ secrets.GH_TOKEN }}
+
+  events-processor:
+    uses: ./.github/workflows/docker-build-multi-arch.yaml
+    with:
+      image-name: ghcr.io/getlago/events-processor
+      registry: ghcr
+      cache-type: disabled
+      platforms: amd64
+      context: events-processor
+      dockerfile: events-processor/Dockerfile
+    secrets: inherit


### PR DESCRIPTION
Build amd64 images for api, front, and events-processor on tag push and publish to ghcr.io/getlago/{service}.

- Add release-images workflow triggered on v* tags
- Use reusable docker-build-multi-arch workflow for each service
- Restrict builds to amd64 platform only
- Disable build cache for release builds
- Support disabled cache-type option in reusable workflow