### PR TITLE
fix(events-processor): Handle RFC3339 timestamp

### DIFF
--- a/events-processor/models/event_test.go
+++ b/events-processor/models/event_test.go
@@ -47,12 +47,12 @@ func TestToEnrichedEvent(t *testing.T) {
 			Code:                    "api_calls",
 			PreciseTotalAmountCents: "100.00",
 			Source:                  HTTP_RUBY,
-			Timestamp:               "2025-03-03T13:03:29Z",
+			Timestamp:               "2025-03-03 13:03:29",
 		}
 
 		result := event.ToEnrichedEvent()
 		assert.False(t, result.Success())
-		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-03T13:03:29Z\": invalid syntax", result.ErrorMsg())
+		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-03 13:03:29\": invalid syntax", result.ErrorMsg())
 		assert.False(t, result.Retryable)
 	})
 }

--- a/events-processor/processors/events_processor/enrichment_service_test.go
+++ b/events-processor/processors/events_processor/enrichment_service_test.go
@@ -52,7 +52,7 @@ func TestEnrichEvent(t *testing.T) {
 			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
 			ExternalSubscriptionID: "sub_id",
 			Code:                   "api_calls",
-			Timestamp:              "2025-03-06T12:00:00Z",
+			Timestamp:              "2025-03-06 12:00:00",
 			Source:                 "SQS",
 		}
 
@@ -70,7 +70,7 @@ func TestEnrichEvent(t *testing.T) {
 
 		result := processor.EnrichEvent(&event)
 		assert.False(t, result.Success())
-		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-06T12:00:00Z\": invalid syntax", result.ErrorMsg())
+		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-06 12:00:00\": invalid syntax", result.ErrorMsg())
 		assert.Equal(t, "build_enriched_event", result.ErrorCode())
 		assert.Equal(t, "Error while converting event to enriched event", result.ErrorMessage())
 	})

--- a/events-processor/processors/events_processor/processor_test.go
+++ b/events-processor/processors/events_processor/processor_test.go
@@ -222,7 +222,7 @@ func TestProcessEvent(t *testing.T) {
 			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
 			ExternalSubscriptionID: "sub_id",
 			Code:                   "api_calls",
-			Timestamp:              "2025-03-06T12:00:00Z",
+			Timestamp:              "2025-03-06 12:00:00",
 			Source:                 "SQS",
 		}
 
@@ -240,7 +240,7 @@ func TestProcessEvent(t *testing.T) {
 
 		result := processor.processEvent(context.Background(), &event)
 		assert.False(t, result.Success())
-		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-06T12:00:00Z\": invalid syntax", result.ErrorMsg())
+		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-06 12:00:00\": invalid syntax", result.ErrorMsg())
 		assert.Equal(t, "build_enriched_event", result.ErrorCode())
 		assert.Equal(t, "Error while converting event to enriched event", result.ErrorMessage())
 	})

--- a/events-processor/utils/time.go
+++ b/events-processor/utils/time.go
@@ -15,12 +15,16 @@ func ToTime(timestamp any) Result[time.Time] {
 	switch timestamp := timestamp.(type) {
 	case string:
 		floatTimestamp, err := strconv.ParseFloat(timestamp, 64)
-		if err != nil {
-			return FailedResult[time.Time](err)
+		if err == nil {
+			seconds = int64(floatTimestamp)
+			nanoseconds = int64((floatTimestamp - float64(seconds)) * 1e9)
+		} else {
+			timeValue, timeError := time.Parse(time.RFC3339, timestamp)
+			if timeError != nil {
+				return FailedResult[time.Time](err)
+			}
+			return SuccessResult[time.Time](timeValue)
 		}
-
-		seconds = int64(floatTimestamp)
-		nanoseconds = int64((floatTimestamp - float64(seconds)) * 1e9)
 
 	case int:
 		seconds = int64(timestamp)
@@ -47,10 +51,17 @@ func ToFloat64Timestamp(timeValue any) Result[float64] {
 	switch timestamp := timeValue.(type) {
 	case string:
 		floatTimestamp, err := strconv.ParseFloat(timestamp, 64)
-		if err != nil {
-			return FailedResult[float64](err)
+		if err == nil {
+			value = math.Trunc(floatTimestamp*1000) / 1000
+		} else {
+			timeValue, timeError := time.Parse(time.RFC3339, timestamp)
+
+			if timeError != nil {
+				return FailedResult[float64](err)
+			}
+			value = float64(timeValue.UnixMilli()) / 1e3
 		}
-		value = math.Trunc(floatTimestamp*1000) / 1000
+
 	case int:
 		value = float64(timestamp)
 	case int64:

--- a/events-processor/utils/time_test.go
+++ b/events-processor/utils/time_test.go
@@ -35,6 +35,14 @@ func TestToTime(t *testing.T) {
 				timestamp:   fmt.Sprintf("%f", 1741007009.344),
 				parsedValue: valueFloat,
 			},
+			expectedTime{
+				timestamp:   "2025-03-03T13:03:29Z",
+				parsedValue: valueInt,
+			},
+			expectedTime{
+				timestamp:   "2025-03-03T13:03:29.344Z",
+				parsedValue: valueFloat,
+			},
 		}
 
 		for _, test := range expectations {
@@ -45,9 +53,9 @@ func TestToTime(t *testing.T) {
 	})
 
 	t.Run("With unsuported time format", func(t *testing.T) {
-		result := ToTime("2025-03-03T13:03:29Z")
+		result := ToTime("2025-03-03 13:03:29")
 		assert.False(t, result.Success())
-		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-03T13:03:29Z\": invalid syntax", result.ErrorMsg())
+		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-03 13:03:29\": invalid syntax", result.ErrorMsg())
 	})
 }
 
@@ -75,6 +83,14 @@ func TestToFloat64Timestamp(t *testing.T) {
 				timestamp:   fmt.Sprintf("%f", 1741007009.344),
 				parsedValue: 1741007009.344,
 			},
+			expectedTime64{
+				timestamp:   "2025-03-03T13:03:29Z",
+				parsedValue: 1741007009.0,
+			},
+			expectedTime64{
+				timestamp:   "2025-03-03T13:03:29.344Z",
+				parsedValue: 1741007009.344,
+			},
 		}
 
 		for _, test := range expectations {
@@ -85,9 +101,9 @@ func TestToFloat64Timestamp(t *testing.T) {
 	})
 
 	t.Run("With unsuported time format", func(t *testing.T) {
-		result := ToFloat64Timestamp("2025-03-03T13:03:29Z")
+		result := ToFloat64Timestamp("2025-03-03 13:03:29")
 		assert.False(t, result.Success())
-		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-03T13:03:29Z\": invalid syntax", result.ErrorMsg())
+		assert.Equal(t, "strconv.ParseFloat: parsing \"2025-03-03 13:03:29\": invalid syntax", result.ErrorMsg())
 	})
 }
 
@@ -110,7 +126,7 @@ func TestCustomTime(t *testing.T) {
 	t.Run("With invalid time format", func(t *testing.T) {
 		ct := &CustomTime{}
 
-		time := "2025-03-03T13:03:29Z"
+		time := "2025-03-03 13:03:29"
 		err := ct.UnmarshalJSON([]byte(time))
 		assert.Error(t, err)
 	})


### PR DESCRIPTION
This PR fixes the handling of ingested events with timestamp using RFC3339 format.

It avoid failed events processing with error: `strconv.ParseFloat: parsing "2026-03-02T12:37:52.356Z": invalid syntax`