### PR TITLE
fix(events-processor): Ensure grouped by are set when matching a single flat filter

### DIFF
--- a/events-processor/models/flat_filters.go
+++ b/events-processor/models/flat_filters.go
@@ -157,6 +157,7 @@ func (ff *FlatFilter) ToDefaultFilter() *FlatFilter {
 		ChargeUpdatedAt:     ff.ChargeUpdatedAt,
 		PayInAdvance:        ff.PayInAdvance,
 		AcceptsTargetWallet: ff.AcceptsTargetWallet,
+		PricingGroupKeys:    ff.PricingGroupKeys,
 	}
 
 	return defaultFilter

--- a/events-processor/models/flat_filters_test.go
+++ b/events-processor/models/flat_filters_test.go
@@ -236,6 +236,7 @@ func TestToDefaultFilter(t *testing.T) {
 			},
 			PayInAdvance:        true,
 			AcceptsTargetWallet: false,
+			PricingGroupKeys:    []string{"region"},
 		}
 
 		filter := flatFilter.ToDefaultFilter()
@@ -244,6 +245,7 @@ func TestToDefaultFilter(t *testing.T) {
 		assert.Equal(t, filter.PlanID, flatFilter.PlanID)
 		assert.Equal(t, filter.ChargeID, flatFilter.ChargeID)
 		assert.Equal(t, filter.ChargeUpdatedAt, flatFilter.ChargeUpdatedAt)
+		assert.Equal(t, filter.PricingGroupKeys, flatFilter.PricingGroupKeys)
 		assert.Nil(t, filter.ChargeFilterID)
 		assert.Nil(t, filter.ChargeFilterUpdatedAt)
 		assert.Nil(t, filter.Filters)

--- a/events-processor/processors/events_processor/enrichment_service.go
+++ b/events-processor/processors/events_processor/enrichment_service.go
@@ -165,7 +165,12 @@ func enrichWithPricingGroupKeys(event *models.EnrichedEvent) {
 
 	if event.FlatFilter.PricingGroupKeys != nil {
 		for _, key := range event.FlatFilter.PricingGroupKeys {
-			event.GroupedBy[key] = fmt.Sprintf("%v", event.Properties[key])
+			property := event.Properties[key]
+			if property != nil {
+				event.GroupedBy[key] = fmt.Sprintf("%v", property)
+			} else {
+				event.GroupedBy[key] = ""
+			}
 		}
 	}
 

--- a/events-processor/processors/events_processor/enrichment_service_test.go
+++ b/events-processor/processors/events_processor/enrichment_service_test.go
@@ -225,6 +225,118 @@ func TestEnrichEvent(t *testing.T) {
 		assert.Equal(t, map[string]string{}, eventResult2.GroupedBy)
 	})
 
+	t.Run("With a flat filter without charge filter ID and pricing_group_keys", func(t *testing.T) {
+		processor, mockedStore, delete := setupEnrichmentTestEnv(t)
+		defer delete()
+
+		properties := map[string]any{
+			"value":   "12.12",
+			"scheme":  "visa",
+			"country": "US",
+			"type":    "debit",
+		}
+
+		event := models.Event{
+			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			ExternalSubscriptionID: "sub_id",
+			Code:                   "api_calls",
+			Timestamp:              1741007009.0,
+			Properties:             properties,
+			Source:                 "SQS",
+		}
+
+		bm := models.BillableMetric{
+			ID:              "bm123",
+			OrganizationID:  event.OrganizationID,
+			Code:            event.Code,
+			AggregationType: models.AggregationTypeWeightedSum,
+			FieldName:       "api_requests",
+			Expression:      "round(event.properties.value)",
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+		mockBmLookup(mockedStore, &bm)
+
+		sub := models.Subscription{ID: "sub123"}
+		mockSubscriptionLookup(mockedStore, &sub)
+
+		now := time.Now()
+
+		flatFilter := &models.FlatFilter{
+			OrganizationID:     "org_id",
+			BillableMetricCode: "api_calls",
+			PlanID:             "plan_id",
+			ChargeID:           "charge_id1",
+			ChargeUpdatedAt:    now,
+			PricingGroupKeys:   []string{"country", "type"},
+		}
+		mockFlatFiltersLookup(mockedStore, []*models.FlatFilter{flatFilter})
+
+		result := processor.EnrichEvent(&event)
+		assert.True(t, result.Success())
+		assert.Equal(t, 1, len(result.Value()))
+
+		eventResult := result.Value()[0]
+		assert.Equal(t, "12", *eventResult.Value)
+		assert.Equal(t, "charge_id1", *eventResult.ChargeID)
+		assert.Equal(t, map[string]string{"country": "US", "type": "debit"}, eventResult.GroupedBy)
+	})
+
+	t.Run("With a flat filter without charge filter ID and pricing_group_keys and event does not have group properties", func(t *testing.T) {
+		processor, mockedStore, delete := setupEnrichmentTestEnv(t)
+		defer delete()
+
+		properties := map[string]any{
+			"value":  "12.12",
+			"scheme": "visa",
+		}
+
+		event := models.Event{
+			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			ExternalSubscriptionID: "sub_id",
+			Code:                   "api_calls",
+			Timestamp:              1741007009.0,
+			Properties:             properties,
+			Source:                 "SQS",
+		}
+
+		bm := models.BillableMetric{
+			ID:              "bm123",
+			OrganizationID:  event.OrganizationID,
+			Code:            event.Code,
+			AggregationType: models.AggregationTypeWeightedSum,
+			FieldName:       "api_requests",
+			Expression:      "round(event.properties.value)",
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+		mockBmLookup(mockedStore, &bm)
+
+		sub := models.Subscription{ID: "sub123"}
+		mockSubscriptionLookup(mockedStore, &sub)
+
+		now := time.Now()
+
+		flatFilter := &models.FlatFilter{
+			OrganizationID:     "org_id",
+			BillableMetricCode: "api_calls",
+			PlanID:             "plan_id",
+			ChargeID:           "charge_id1",
+			ChargeUpdatedAt:    now,
+			PricingGroupKeys:   []string{"country", "type"},
+		}
+		mockFlatFiltersLookup(mockedStore, []*models.FlatFilter{flatFilter})
+
+		result := processor.EnrichEvent(&event)
+		assert.True(t, result.Success())
+		assert.Equal(t, 1, len(result.Value()))
+
+		eventResult := result.Value()[0]
+		assert.Equal(t, "12", *eventResult.Value)
+		assert.Equal(t, "charge_id1", *eventResult.ChargeID)
+		assert.Equal(t, map[string]string{"country": "", "type": ""}, eventResult.GroupedBy)
+	})
+
 	t.Run("With a flat filter with pricing group keys", func(t *testing.T) {
 		processor, mockedStore, delete := setupEnrichmentTestEnv(t)
 		defer delete()


### PR DESCRIPTION
This PR fixes the assignment of pricing_group_keys/grouped_by on event_enriched_expanded when no charge_filter_id is nil