### PR TITLE
misc(events-processor) Improve logger setup

### DIFF
--- a/events-processor/CLAUDE.md
+++ b/events-processor/CLAUDE.md
@@ -1,0 +1,10 @@
+# Events Processor
+
+## Build & Test
+
+Run tests:
+```
+lago exec events-processor go test ./...
+```
+
+Direct `go build` / `go test` won't work locally due to CGO dependencies. Always use `lago exec` to run commands inside the service container.

--- a/events-processor/config/database/database.go
+++ b/events-processor/config/database/database.go
@@ -39,10 +39,12 @@ func NewConnection(config DBConfig) (*DB, error) {
 	})
 
 	conn, err := OpenConnection(dialector)
-	if err == nil {
-		conn.pool = pool
+	if err != nil {
+		pool.Close()
+		return nil, err
 	}
-	return conn, err
+	conn.pool = pool
+	return conn, nil
 }
 
 func OpenConnection(dialector gorm.Dialector) (*DB, error) {

--- a/events-processor/config/database/database.go
+++ b/events-processor/config/database/database.go
@@ -13,7 +13,6 @@ import (
 
 type DB struct {
 	Connection *gorm.DB
-	logger     *slog.Logger
 	pool       *pgxpool.Pool
 }
 
@@ -23,9 +22,6 @@ type DBConfig struct {
 }
 
 func NewConnection(config DBConfig) (*DB, error) {
-	logger := slog.Default()
-	logger = logger.With("component", "db")
-
 	poolConfig, err := pgxpool.ParseConfig(config.Url)
 	if err != nil {
 		return nil, err
@@ -42,14 +38,15 @@ func NewConnection(config DBConfig) (*DB, error) {
 		Conn: stdlib.OpenDBFromPool(pool),
 	})
 
-	conn, err := OpenConnection(logger, dialector)
+	conn, err := OpenConnection(dialector)
 	if err == nil {
 		conn.pool = pool
 	}
 	return conn, err
 }
 
-func OpenConnection(logger *slog.Logger, dialector gorm.Dialector) (*DB, error) {
+func OpenConnection(dialector gorm.Dialector) (*DB, error) {
+	logger := slog.Default().With("component", "db")
 	gormLogger := slogGorm.New(
 		slogGorm.WithHandler(logger.Handler()),
 	)
@@ -62,7 +59,7 @@ func OpenConnection(logger *slog.Logger, dialector gorm.Dialector) (*DB, error) 
 		return nil, err
 	}
 
-	return &DB{Connection: db, logger: logger}, nil
+	return &DB{Connection: db}, nil
 }
 
 func (db *DB) Close() {

--- a/events-processor/config/database/database_test.go
+++ b/events-processor/config/database/database_test.go
@@ -22,5 +22,5 @@ func TestNewConnection(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, db)
 	assert.NotNil(t, db.Connection)
-	assert.NotNil(t, db.logger)
+	assert.NotNil(t, db.pool)
 }

--- a/events-processor/config/kafka/consumer.go
+++ b/events-processor/config/kafka/consumer.go
@@ -219,8 +219,8 @@ func (cg *ConsumerGroup) gracefulShutdown() {
 }
 
 func NewConsumerGroup(serverConfig ServerConfig, cfg *ConsumerGroupConfig) (*ConsumerGroup, error) {
-	logger := slog.Default()
-	logger = logger.With("kafka-topic-consumer", cfg.Topic)
+	logger := slog.New(utils.NewLevelHandler(slog.LevelInfo, slog.Default().Handler())).
+		With("kafka-topic-consumer", cfg.Topic)
 
 	cg := &ConsumerGroup{
 		consumers:      make(map[TopicPartition]*PartitionConsumer),

--- a/events-processor/config/kafka/kafka.go
+++ b/events-processor/config/kafka/kafka.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/getlago/lago/events-processor/config/tracing"
+	"github.com/getlago/lago/events-processor/utils"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"github.com/twmb/franz-go/plugin/kslog"
@@ -24,8 +25,8 @@ type ServerConfig struct {
 }
 
 func NewKafkaClient(serverConfig ServerConfig, config []kgo.Opt) (*kgo.Client, error) {
-	logger := slog.Default()
-	logger = logger.With("component", "kafka")
+	logger := slog.New(utils.NewLevelHandler(slog.LevelInfo, slog.Default().Handler())).
+		With("component", "kafka")
 
 	opts := []kgo.Opt{
 		kgo.SeedBrokers(serverConfig.Servers...),

--- a/events-processor/config/kafka/producer.go
+++ b/events-processor/config/kafka/producer.go
@@ -37,8 +37,8 @@ func NewProducer(serverConfig ServerConfig, cfg *ProducerConfig) (*Producer, err
 		return nil, err
 	}
 
-	logger := slog.Default()
-	logger = logger.With("component", "kafka-producer")
+	logger := slog.New(utils.NewLevelHandler(slog.LevelInfo, slog.Default().Handler())).
+		With("component", "kafka-producer")
 
 	pdr := &Producer{
 		client: kcl,

--- a/events-processor/config/tracing/datadog_tracer.go
+++ b/events-processor/config/tracing/datadog_tracer.go
@@ -100,7 +100,7 @@ func (p *DatadogTracerProvider) GetKafkaHooks() []kgo.Hook {
 	}
 }
 
-func NewDatadogTracerProvider(logger *slog.Logger, opts TracerProviderOptions) *DatadogTracerProvider {
+func NewDatadogTracerProvider(opts TracerProviderOptions) *DatadogTracerProvider {
 	options := []ddtracer.StartOption{
 		ddtracer.WithService(opts.ServiceName),
 		ddtracer.WithEnv(opts.Env),
@@ -109,7 +109,7 @@ func NewDatadogTracerProvider(logger *slog.Logger, opts TracerProviderOptions) *
 	options = append(options, ddtracer.WithAgentAddr(opts.ProviderURL))
 
 	ddtracer.Start(options...)
-	logger.Info("Datadog tracer started",
+	slog.Info("Datadog tracer started",
 		slog.String("service", opts.ServiceName),
 	)
 

--- a/events-processor/config/tracing/otel_tracer.go
+++ b/events-processor/config/tracing/otel_tracer.go
@@ -168,7 +168,7 @@ func NewOTelTracerProvider(opts TracerProviderOptions) *OTelTracerProvider {
 	)
 
 	if err != nil {
-		slog.Error("Could not set open telemetry resource: %v", slog.String("error", err.Error()))
+		slog.Error("Could not set open telemetry resource", slog.String("error", err.Error()))
 		return nil
 	}
 

--- a/events-processor/config/tracing/otel_tracer.go
+++ b/events-processor/config/tracing/otel_tracer.go
@@ -96,7 +96,6 @@ func (t *OTelTracer) StartSpan(ctx context.Context, operationName string, opts .
 // OTelTracerProvider implements the TracerProvider interface
 type OTelTracerProvider struct {
 	ctx      context.Context
-	logger   *slog.Logger
 	exporter *otlptrace.Exporter
 	meter    *otlpmetricgrpc.Exporter
 	options  TracerProviderOptions
@@ -105,12 +104,12 @@ type OTelTracerProvider struct {
 func (p *OTelTracerProvider) Stop() {
 	err := p.exporter.Shutdown(p.ctx)
 	if err != nil {
-		p.logger.Error("Could not shutdown exporter", slog.String("error", err.Error()))
+		slog.Error("Could not shutdown exporter", slog.String("error", err.Error()))
 	}
 
 	err = p.meter.Shutdown(p.ctx)
 	if err != nil {
-		p.logger.Error("Could not shutdown meter", slog.String("error", err.Error()))
+		slog.Error("Could not shutdown meter", slog.String("error", err.Error()))
 	}
 }
 
@@ -145,17 +144,17 @@ func (p *OTelTracerProvider) GetKafkaHooks() []kgo.Hook {
 	return kotelService.Hooks()
 }
 
-func NewOTelTracerProvider(logger *slog.Logger, opts TracerProviderOptions) *OTelTracerProvider {
+func NewOTelTracerProvider(opts TracerProviderOptions) *OTelTracerProvider {
 	ctx := context.Background()
 	exporter, err := initTracerExporter(ctx, opts)
 	if err != nil {
-		logger.Error("Could not create open telemetry exporter", slog.String("error", err.Error()))
+		slog.Error("Could not create open telemetry exporter", slog.String("error", err.Error()))
 		return nil
 	}
 
 	meter, err := initMeterExporter(ctx, opts)
 	if err != nil {
-		logger.Error("Could not create open telemetry meter", slog.String("error", err.Error()))
+		slog.Error("Could not create open telemetry meter", slog.String("error", err.Error()))
 		return nil
 	}
 
@@ -169,7 +168,7 @@ func NewOTelTracerProvider(logger *slog.Logger, opts TracerProviderOptions) *OTe
 	)
 
 	if err != nil {
-		logger.Error("Could not set open telemetry resource: %v", slog.String("error", err.Error()))
+		slog.Error("Could not set open telemetry resource: %v", slog.String("error", err.Error()))
 		return nil
 	}
 
@@ -192,7 +191,6 @@ func NewOTelTracerProvider(logger *slog.Logger, opts TracerProviderOptions) *OTe
 
 	return &OTelTracerProvider{
 		ctx:      ctx,
-		logger:   logger,
 		exporter: exporter,
 		meter:    meter,
 		options:  opts,

--- a/events-processor/config/tracing/tracer.go
+++ b/events-processor/config/tracing/tracer.go
@@ -3,7 +3,6 @@ package tracing
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"sync"
 
@@ -44,7 +43,7 @@ const (
 // If nil, it will check for the `DD_TRACE_ENABLED` (datadog)
 // and finaly `OTEL_EXPORTER_OTLP_ENDPOINT` (opentelemetry)
 // An "Empty" provider will be returned if no provider is found
-func InitTracerProvider(logger *slog.Logger) TracerProvider {
+func InitTracerProvider() TracerProvider {
 	tracingProvider := findTracingProvider(os.Getenv(envTracingProvider))
 
 	var provider TracerProvider
@@ -52,9 +51,9 @@ func InitTracerProvider(logger *slog.Logger) TracerProvider {
 
 	switch tracingProvider {
 	case OTelProvider:
-		provider = NewOTelTracerProvider(logger, opts)
+		provider = NewOTelTracerProvider(opts)
 	case DatadogProvider:
-		provider = NewDatadogTracerProvider(logger, opts)
+		provider = NewDatadogTracerProvider(opts)
 	default:
 		provider = &EmptyTracerProvider{}
 	}

--- a/events-processor/main.go
+++ b/events-processor/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/getlago/lago/events-processor/config/tracing"
 	"github.com/getlago/lago/events-processor/processors"
+	"github.com/getlago/lago/events-processor/utils"
 )
 
 const (
@@ -24,8 +25,16 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-		With("service", "post_process")
+	env := utils.GetEnvOrDefault(envEnv, "development")
+
+	logLevel := slog.LevelInfo
+	if env == "development" {
+		logLevel = slog.LevelDebug
+	}
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	})).With("service", "post_process")
 	slog.SetDefault(logger)
 
 	setupGracefulShutdown(cancel, logger)
@@ -37,7 +46,7 @@ func main() {
 
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:              os.Getenv(envSentryDsn),
-		Environment:      os.Getenv(envEnv),
+		Environment:      env,
 		Debug:            false,
 		AttachStacktrace: true,
 	})

--- a/events-processor/main.go
+++ b/events-processor/main.go
@@ -37,9 +37,9 @@ func main() {
 	})).With("service", "post_process")
 	slog.SetDefault(logger)
 
-	setupGracefulShutdown(cancel, logger)
+	setupGracefulShutdown(cancel)
 
-	tracerProvider := tracing.InitTracerProvider(logger)
+	tracerProvider := tracing.InitTracerProvider()
 	defer tracerProvider.Stop()
 
 	tracing.InitTracer(tracerProvider)
@@ -59,18 +59,17 @@ func main() {
 
 	// start processing events & loop forever
 	processors.StartProcessingEvents(ctx, &processors.Config{
-		Logger:         logger,
 		TracerProvider: tracerProvider,
 	})
 }
 
-func setupGracefulShutdown(cancel context.CancelFunc, logger *slog.Logger) {
+func setupGracefulShutdown(cancel context.CancelFunc) {
 	signChan := make(chan os.Signal, 1)
 	signal.Notify(signChan, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		sig := <-signChan
-		logger.Info("Received shutdown signal", slog.String("signal", sig.String()))
+		slog.Info("Received shutdown signal", slog.String("signal", sig.String()))
 		cancel()
 	}()
 }

--- a/events-processor/main.go
+++ b/events-processor/main.go
@@ -40,9 +40,12 @@ func main() {
 	setupGracefulShutdown(cancel)
 
 	tracerProvider := tracing.InitTracerProvider()
-	defer tracerProvider.Stop()
-
-	tracing.InitTracer(tracerProvider)
+	if tracerProvider == nil {
+		slog.Error("Failed to initialize tracer provider, tracing disabled")
+	} else {
+		defer tracerProvider.Stop()
+		tracing.InitTracer(tracerProvider)
+	}
 
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:              os.Getenv(envSentryDsn),

--- a/events-processor/processors/events_processor/event_producer_service.go
+++ b/events-processor/processors/events_processor/event_producer_service.go
@@ -18,16 +18,14 @@ type EventProducerService struct {
 	enrichedExpendedProducer kafka.MessageProducer
 	inAdvanceProducer        kafka.MessageProducer
 	deadLetterProducer       kafka.MessageProducer
-	logger                   *slog.Logger
 }
 
-func NewEventProducerService(enrichedProducer, enrichedExpendedProducer, inAdvanceProducer, deadLetterProducer kafka.MessageProducer, logger *slog.Logger) *EventProducerService {
+func NewEventProducerService(enrichedProducer, enrichedExpendedProducer, inAdvanceProducer, deadLetterProducer kafka.MessageProducer) *EventProducerService {
 	return &EventProducerService{
 		enrichedProducer:         enrichedProducer,
 		enrichedExpendedProducer: enrichedExpendedProducer,
 		inAdvanceProducer:        inAdvanceProducer,
 		deadLetterProducer:       deadLetterProducer,
-		logger:                   logger,
 	}
 }
 
@@ -37,7 +35,7 @@ func (eps *EventProducerService) ProduceEnrichedEvent(context context.Context, e
 	err := eps.produceEvent(context, event, msgKey, eps.enrichedProducer)
 
 	if err != nil {
-		eps.logger.Error("error while marshaling enriched events")
+		slog.Error("error while marshaling enriched events")
 		utils.CaptureError(err)
 	}
 }
@@ -71,7 +69,7 @@ func (eps *EventProducerService) ProduceEnrichedExpandedEvent(context context.Co
 
 	err := eps.produceEvent(context, event, msgKey, eps.enrichedExpendedProducer)
 	if err != nil {
-		eps.logger.Error("error while marshaling enriched expended events")
+		slog.Error("error while marshaling enriched expended events")
 		utils.CaptureError(err)
 	}
 }
@@ -82,7 +80,7 @@ func (eps *EventProducerService) ProduceChargedInAdvanceEvent(context context.Co
 	err := eps.produceEvent(context, event, msgKey, eps.inAdvanceProducer)
 
 	if err != nil {
-		eps.logger.Error("error while marshaling charged in advance events")
+		slog.Error("error while marshaling charged in advance events")
 		utils.CaptureError(err)
 	}
 }
@@ -98,7 +96,7 @@ func (eps *EventProducerService) ProduceToDeadLetterQueue(context context.Contex
 
 	eventJson, err := json.Marshal(failedEvent)
 	if err != nil {
-		eps.logger.Error("error while marshaling failed event with error details")
+		slog.Error("error while marshaling failed event with error details")
 		utils.CaptureError(err)
 	}
 
@@ -107,7 +105,7 @@ func (eps *EventProducerService) ProduceToDeadLetterQueue(context context.Contex
 	})
 
 	if !pushed {
-		eps.logger.Error("error while pushing to dead letter topic", slog.String("topic", eps.deadLetterProducer.GetTopic()))
+		slog.Error("error while pushing to dead letter topic", slog.String("topic", eps.deadLetterProducer.GetTopic()))
 		utils.CaptureErrorResultWithExtra(errorResult, "event", event)
 	}
 }

--- a/events-processor/processors/events_processor/event_producer_service_test.go
+++ b/events-processor/processors/events_processor/event_producer_service_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
-	"os"
 	"testing"
 	"time"
 
@@ -21,7 +19,6 @@ var (
 	enrichedExpandedProducer *tests.MockMessageProducer
 	inAdvanceProducer        *tests.MockMessageProducer
 	deadLetterProducer       *tests.MockMessageProducer
-	logger                   *slog.Logger
 )
 
 func setupProducerServiceEnv() {
@@ -30,15 +27,11 @@ func setupProducerServiceEnv() {
 	inAdvanceProducer = &tests.MockMessageProducer{}
 	deadLetterProducer = &tests.MockMessageProducer{}
 
-	logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	slog.SetDefault(logger)
-
 	producerService = NewEventProducerService(
 		enrichedProducer,
 		enrichedExpandedProducer,
 		inAdvanceProducer,
 		deadLetterProducer,
-		logger,
 	)
 }
 

--- a/events-processor/processors/events_processor/processor.go
+++ b/events-processor/processors/events_processor/processor.go
@@ -16,16 +16,14 @@ import (
 )
 
 type EventProcessor struct {
-	logger            *slog.Logger
 	EnrichmentService *EventEnrichmentService
 	ProducerService   *EventProducerService
 	RefreshService    *SubscriptionRefreshService
 	CacheService      *CacheService
 }
 
-func NewEventProcessor(logger *slog.Logger, enrichmentService *EventEnrichmentService, producerService *EventProducerService, refreshService *SubscriptionRefreshService, cacheService *CacheService) *EventProcessor {
+func NewEventProcessor(enrichmentService *EventEnrichmentService, producerService *EventProducerService, refreshService *SubscriptionRefreshService, cacheService *CacheService) *EventProcessor {
 	return &EventProcessor{
-		logger:            logger,
 		EnrichmentService: enrichmentService,
 		ProducerService:   producerService,
 		RefreshService:    refreshService,
@@ -53,7 +51,7 @@ func (processor *EventProcessor) ProcessEvents(ctx context.Context, records []*k
 				event := models.Event{}
 				err := json.Unmarshal(record.Value, &event)
 				if err != nil {
-					processor.logger.Error("Error unmarshalling message", slog.String("error", err.Error()))
+					slog.Error("Error unmarshalling message", slog.String("error", err.Error()))
 					utils.CaptureError(err)
 
 					mu.Lock()
@@ -65,7 +63,7 @@ func (processor *EventProcessor) ProcessEvents(ctx context.Context, records []*k
 
 				result := processor.processEvent(ctx, &event)
 				if result.Failure() {
-					processor.logger.Error(
+					slog.Error(
 						result.ErrorMessage(),
 						slog.String("error_code", result.ErrorCode()),
 						slog.String("error", result.ErrorMsg()),

--- a/events-processor/processors/events_processor/processor_test.go
+++ b/events-processor/processors/events_processor/processor_test.go
@@ -2,8 +2,6 @@ package events_processor
 
 import (
 	"context"
-	"log/slog"
-	"os"
 	"testing"
 	"time"
 
@@ -31,15 +29,11 @@ func setupProducers() *testProducerService {
 	inAdvanceProducer := tests.MockMessageProducer{}
 	deadLetterProducer := tests.MockMessageProducer{}
 
-	logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	slog.SetDefault(logger)
-
 	producers := NewEventProducerService(
 		&enrichedProducer,
 		&enrichedExpandedProducer,
 		&inAdvanceProducer,
 		&deadLetterProducer,
-		logger,
 	)
 
 	return &testProducerService{
@@ -52,9 +46,6 @@ func setupProducers() *testProducerService {
 }
 
 func setupProcessorTestEnv(t *testing.T) (*EventProcessor, *tests.MockedStore, *testProducerService, *tests.MockFlagStore, func()) {
-	logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	slog.SetDefault(logger)
-
 	mockedStore, delete := tests.SetupMockStore(t)
 	apiStore := models.NewApiStore(mockedStore.DB)
 
@@ -68,7 +59,6 @@ func setupProcessorTestEnv(t *testing.T) (*EventProcessor, *tests.MockedStore, *
 	flagger := NewSubscriptionRefreshService(&flagStore)
 
 	processor := NewEventProcessor(
-		logger,
 		NewEventEnrichmentService(apiStore),
 		testProducers.producers,
 		flagger,

--- a/events-processor/processors/main_processor.go
+++ b/events-processor/processors/main_processor.go
@@ -49,7 +49,6 @@ const (
 )
 
 type Config struct {
-	Logger         *slog.Logger
 	TracerProvider tracing.TracerProvider
 }
 
@@ -128,7 +127,7 @@ func initChargeCacheStore(ctx context.Context) (*models.ChargeCache, error) {
 func StartProcessingEvents(ctx context.Context, config *Config) {
 	serverBrokers := utils.ParseBrokersEnv(os.Getenv(envLagoKafkaBootstrapServers))
 	if len(serverBrokers) == 0 {
-		config.Logger.Error("brokers not found")
+		slog.Error("brokers not found")
 		panic("brokers not found")
 	}
 
@@ -143,27 +142,27 @@ func StartProcessingEvents(ctx context.Context, config *Config) {
 
 	eventsEnrichedProducer, err := initProducer(ctx, envLagoKafkaEnrichedEventsTopic)
 	if err != nil {
-		utils.LogAndPanic(config.Logger, err, "failed to initialize enriched events producer")
+		utils.LogAndPanic(err, "failed to initialize enriched events producer")
 	}
 
 	eventsEnrichedExpandedProducer, err := initProducer(ctx, envLagoKafkaEnrichedEventsExpandedTopic)
 	if err != nil {
-		utils.LogAndPanic(config.Logger, err, "failed to initialize enriched events expanded producer")
+		utils.LogAndPanic(err, "failed to initialize enriched events expanded producer")
 	}
 
 	eventsInAdvanceProducer, err := initProducer(ctx, envLagoKafkaEventsChargedInAdvanceTopic)
 	if err != nil {
-		utils.LogAndPanic(config.Logger, err, "failed to initialize events charged in advance producer")
+		utils.LogAndPanic(err, "failed to initialize events charged in advance producer")
 	}
 
 	eventsDeadLetterQueue, err := initProducer(ctx, envLagoKafkaEventsDeadLetterTopic)
 	if err != nil {
-		utils.LogAndPanic(config.Logger, err, "failed to initialize events dead letter queue producer")
+		utils.LogAndPanic(err, "failed to initialize events dead letter queue producer")
 	}
 
 	maxConns, err := utils.GetEnvAsInt(envLagoEventsProcessorDatabaseMaxConnections, 200)
 	if err != nil {
-		utils.LogAndPanic(config.Logger, err, "Error converting max connections into integer")
+		utils.LogAndPanic(err, "Error converting max connections into integer")
 	}
 
 	dbConfig := database.DBConfig{
@@ -173,33 +172,31 @@ func StartProcessingEvents(ctx context.Context, config *Config) {
 
 	db, err := database.NewConnection(dbConfig)
 	if err != nil {
-		utils.LogAndPanic(config.Logger, err, "Error connecting to the database")
+		utils.LogAndPanic(err, "Error connecting to the database")
 	}
 	apiStore = models.NewApiStore(db)
 	defer db.Close()
 
 	flagger, err := initFlagStore(ctx, "subscription_refreshed")
 	if err != nil {
-		utils.LogAndPanic(config.Logger, err, "Error connecting to the flag store")
+		utils.LogAndPanic(err, "Error connecting to the flag store")
 	}
 	defer flagger.Close()
 
 	cacher, err := initChargeCacheStore(ctx)
 	if err != nil {
-		utils.LogAndPanic(config.Logger, err, "Error connecting to the charge cache store")
+		utils.LogAndPanic(err, "Error connecting to the charge cache store")
 	}
 	chargeCacheStore = cacher
 	defer chargeCacheStore.CacheStore.Close()
 
 	processor = events_processor.NewEventProcessor(
-		config.Logger,
 		events_processor.NewEventEnrichmentService(apiStore),
 		events_processor.NewEventProducerService(
 			eventsEnrichedProducer,
 			eventsEnrichedExpandedProducer,
 			eventsInAdvanceProducer,
 			eventsDeadLetterQueue,
-			config.Logger,
 		),
 		events_processor.NewSubscriptionRefreshService(flagger),
 		events_processor.NewCacheService(chargeCacheStore),
@@ -215,10 +212,10 @@ func StartProcessingEvents(ctx context.Context, config *Config) {
 			},
 		})
 	if err != nil {
-		utils.LogAndPanic(config.Logger, err, "Error starting the event consumer")
+		utils.LogAndPanic(err, "Error starting the event consumer")
 	}
 
-	config.Logger.Info("Starting event consumer")
+	slog.Info("Starting event consumer")
 	cg.Start(ctx)
-	config.Logger.Info("Event processor stopped")
+	slog.Info("Event processor stopped")
 }

--- a/events-processor/tests/mocked_store.go
+++ b/events-processor/tests/mocked_store.go
@@ -1,8 +1,6 @@
 package tests
 
 import (
-	"log/slog"
-	"os"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -27,9 +25,7 @@ func SetupMockStore(t *testing.T) (*MockedStore, func()) {
 		DriverName: "postgres",
 	})
 
-	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(-4)}))
-
-	db, err := database.OpenConnection(logger, dialector)
+	db, err := database.OpenConnection(dialector)
 	if err != nil {
 		t.Fatalf("Failed to open gorm connection: %v", err)
 	}

--- a/events-processor/utils/error_tracker.go
+++ b/events-processor/utils/error_tracker.go
@@ -27,8 +27,8 @@ func CaptureError(err error) {
 	sentry.CaptureException(err)
 }
 
-func LogAndPanic(logger *slog.Logger, err error, message string) {
-	logger.Error(message, slog.String("error", err.Error()))
+func LogAndPanic(err error, message string) {
+	slog.Error(message, slog.String("error", err.Error()))
 	CaptureError(err)
 	panic(err.Error())
 }

--- a/events-processor/utils/logger.go
+++ b/events-processor/utils/logger.go
@@ -16,8 +16,8 @@ func NewLevelHandler(level slog.Leveler, handler slog.Handler) *LevelHandler {
 	return &LevelHandler{level: level, handler: handler}
 }
 
-func (h *LevelHandler) Enabled(_ context.Context, level slog.Level) bool {
-	return level >= h.level.Level()
+func (h *LevelHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return level >= h.level.Level() && h.handler.Enabled(ctx, level)
 }
 
 func (h *LevelHandler) Handle(ctx context.Context, r slog.Record) error {

--- a/events-processor/utils/logger.go
+++ b/events-processor/utils/logger.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"context"
+	"log/slog"
+)
+
+// LevelHandler wraps a slog.Handler and enforces a minimum log level,
+// regardless of the underlying handler's level.
+type LevelHandler struct {
+	level   slog.Leveler
+	handler slog.Handler
+}
+
+func NewLevelHandler(level slog.Leveler, handler slog.Handler) *LevelHandler {
+	return &LevelHandler{level: level, handler: handler}
+}
+
+func (h *LevelHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level.Level()
+}
+
+func (h *LevelHandler) Handle(ctx context.Context, r slog.Record) error {
+	return h.handler.Handle(ctx, r)
+}
+
+func (h *LevelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return NewLevelHandler(h.level, h.handler.WithAttrs(attrs))
+}
+
+func (h *LevelHandler) WithGroup(name string) slog.Handler {
+	return NewLevelHandler(h.level, h.handler.WithGroup(name))
+}

--- a/events-processor/utils/logger_test.go
+++ b/events-processor/utils/logger_test.go
@@ -10,13 +10,24 @@ import (
 )
 
 func TestLevelHandler_Enabled(t *testing.T) {
-	inner := slog.NewJSONHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelDebug})
-	handler := NewLevelHandler(slog.LevelInfo, inner)
+	t.Run("Filters below LevelHandler threshold", func(t *testing.T) {
+		inner := slog.NewJSONHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelDebug})
+		handler := NewLevelHandler(slog.LevelInfo, inner)
 
-	assert.False(t, handler.Enabled(context.Background(), slog.LevelDebug))
-	assert.True(t, handler.Enabled(context.Background(), slog.LevelInfo))
-	assert.True(t, handler.Enabled(context.Background(), slog.LevelWarn))
-	assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+		assert.False(t, handler.Enabled(context.Background(), slog.LevelDebug))
+		assert.True(t, handler.Enabled(context.Background(), slog.LevelInfo))
+		assert.True(t, handler.Enabled(context.Background(), slog.LevelWarn))
+		assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+	})
+
+	t.Run("Respects inner handler threshold", func(t *testing.T) {
+		inner := slog.NewJSONHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelError})
+		handler := NewLevelHandler(slog.LevelInfo, inner)
+
+		assert.False(t, handler.Enabled(context.Background(), slog.LevelInfo))
+		assert.False(t, handler.Enabled(context.Background(), slog.LevelWarn))
+		assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+	})
 }
 
 func TestLevelHandler_Handle(t *testing.T) {

--- a/events-processor/utils/logger_test.go
+++ b/events-processor/utils/logger_test.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLevelHandler_Enabled(t *testing.T) {
+	inner := slog.NewJSONHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelDebug})
+	handler := NewLevelHandler(slog.LevelInfo, inner)
+
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelDebug))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelInfo))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelWarn))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestLevelHandler_Handle(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(NewLevelHandler(slog.LevelInfo, inner))
+
+	logger.Debug("should be filtered")
+	assert.Empty(t, buf.String())
+
+	logger.Info("should pass")
+	assert.Contains(t, buf.String(), "should pass")
+}
+
+func TestLevelHandler_WithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(NewLevelHandler(slog.LevelInfo, inner)).With("component", "kafka")
+
+	logger.Debug("should be filtered")
+	assert.Empty(t, buf.String())
+
+	logger.Info("should pass")
+	assert.Contains(t, buf.String(), "should pass")
+	assert.Contains(t, buf.String(), "kafka")
+}
+
+func TestLevelHandler_WithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(NewLevelHandler(slog.LevelInfo, inner)).WithGroup("kafka")
+
+	logger.Debug("should be filtered")
+	assert.Empty(t, buf.String())
+
+	logger.Info("should pass", "key", "value")
+	assert.Contains(t, buf.String(), "should pass")
+	assert.Contains(t, buf.String(), "kafka")
+}


### PR DESCRIPTION
This PR improves the logger setup to rely on the `slog.Default()` logger as much as possible, removing the need to pass a custom logger to every services.

The log level is also set to `DEBUG` on the development environment (except on kafka related logs as it is too verbose), to ease the development and local debug.