### PR TITLE
misc(events-processor): Add an events reprocess pipeline

### DIFF
--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -25,6 +25,11 @@ type Event struct {
 
 type SourceMetadata struct {
 	ApiPostProcess bool `json:"api_post_processed"`
+	Reprocess      bool `json:"reprocess"`
+}
+
+func (ev *Event) IsReprocess() bool {
+	return ev.SourceMetadata != nil && ev.SourceMetadata.Reprocess
 }
 
 type EnrichedEvent struct {

--- a/events-processor/processors/events_processor/processor.go
+++ b/events-processor/processors/events_processor/processor.go
@@ -110,6 +110,19 @@ func (processor *EventProcessor) processEvent(ctx context.Context, event *models
 	enrichedEvents := enrichedEventResult.Value()
 	enrichedEvent := enrichedEvents[0]
 
+	if event.IsReprocess() {
+		// When reprocessing events, we only need to produce new enriched expanded events
+		for _, ev := range enrichedEvents {
+			if ev.ChargeID != nil {
+				errgroup.Go(func() error {
+					processor.ProducerService.ProduceEnrichedExpandedEvent(ctx, ev)
+					return nil
+				})
+			}
+		}
+		return utils.SuccessResult(enrichedEvent)
+	}
+
 	errgroup.Go(func() error {
 		processor.ProducerService.ProduceEnrichedEvent(ctx, enrichedEvent)
 		return nil

--- a/events-processor/processors/events_processor/processor_test.go
+++ b/events-processor/processors/events_processor/processor_test.go
@@ -45,7 +45,7 @@ func setupProducers() *testProducerService {
 	}
 }
 
-func setupProcessorTestEnv(t *testing.T) (*EventProcessor, *tests.MockedStore, *testProducerService, *tests.MockFlagStore, func()) {
+func setupProcessorTestEnv(t *testing.T) (*EventProcessor, *tests.MockedStore, *testProducerService, *tests.MockFlagStore, *tests.MockCacheStore, func()) {
 	mockedStore, delete := tests.SetupMockStore(t)
 	apiStore := models.NewApiStore(mockedStore.DB)
 
@@ -65,7 +65,7 @@ func setupProcessorTestEnv(t *testing.T) (*EventProcessor, *tests.MockedStore, *
 		NewCacheService(chargeCacheStore),
 	)
 
-	return processor, mockedStore, testProducers, &flagStore, delete
+	return processor, mockedStore, testProducers, &flagStore, &cacheStore, delete
 }
 
 func mockBmLookup(mock *tests.MockedStore, bm *models.BillableMetric) {
@@ -124,7 +124,7 @@ func mockFlatFiltersLookup(mock *tests.MockedStore, filters []*models.FlatFilter
 
 func TestProcessEvent(t *testing.T) {
 	t.Run("Without Billable Metric", func(t *testing.T) {
-		processor, mockedStore, _, _, delete := setupProcessorTestEnv(t)
+		processor, mockedStore, _, _, _, delete := setupProcessorTestEnv(t)
 		defer delete()
 
 		event := models.Event{
@@ -144,7 +144,7 @@ func TestProcessEvent(t *testing.T) {
 	})
 
 	t.Run("When event source is post processed on API", func(t *testing.T) {
-		processor, mockedStore, testProducers, _, delete := setupProcessorTestEnv(t)
+		processor, mockedStore, testProducers, _, _, delete := setupProcessorTestEnv(t)
 		defer delete()
 
 		properties := map[string]any{
@@ -205,7 +205,7 @@ func TestProcessEvent(t *testing.T) {
 	})
 
 	t.Run("When event source is not post process on API when timestamp is invalid", func(t *testing.T) {
-		processor, mockedStore, _, _, delete := setupProcessorTestEnv(t)
+		processor, mockedStore, _, _, _, delete := setupProcessorTestEnv(t)
 		defer delete()
 
 		event := models.Event{
@@ -236,7 +236,7 @@ func TestProcessEvent(t *testing.T) {
 	})
 
 	t.Run("When event source is not post process on API when no subscriptions are found", func(t *testing.T) {
-		processor, mockedStore, _, _, delete := setupProcessorTestEnv(t)
+		processor, mockedStore, _, _, _, delete := setupProcessorTestEnv(t)
 		defer delete()
 
 		event := models.Event{
@@ -266,7 +266,7 @@ func TestProcessEvent(t *testing.T) {
 	})
 
 	t.Run("When event source is not post process on API with error when fetching subscription", func(t *testing.T) {
-		processor, mockedStore, _, _, delete := setupProcessorTestEnv(t)
+		processor, mockedStore, _, _, _, delete := setupProcessorTestEnv(t)
 		defer delete()
 
 		event := models.Event{
@@ -299,7 +299,7 @@ func TestProcessEvent(t *testing.T) {
 	})
 
 	t.Run("When event source is not post process on API when expression failed to evaluate", func(t *testing.T) {
-		processor, mockedStore, _, _, delete := setupProcessorTestEnv(t)
+		processor, mockedStore, _, _, _, delete := setupProcessorTestEnv(t)
 		defer delete()
 
 		// properties := map[string]any{
@@ -338,7 +338,7 @@ func TestProcessEvent(t *testing.T) {
 	})
 
 	t.Run("When event source is not post process on API and events belongs to an in advance charge", func(t *testing.T) {
-		processor, mockedStore, testProducers, flagger, delete := setupProcessorTestEnv(t)
+		processor, mockedStore, testProducers, flagger, _, delete := setupProcessorTestEnv(t)
 		defer delete()
 
 		properties := map[string]any{
@@ -397,7 +397,7 @@ func TestProcessEvent(t *testing.T) {
 	})
 
 	t.Run("When event source is not post processed on API and it matches multiple charges", func(t *testing.T) {
-		processor, mockedStore, testProducers, _, delete := setupProcessorTestEnv(t)
+		processor, mockedStore, testProducers, _, _, delete := setupProcessorTestEnv(t)
 		defer delete()
 
 		properties := map[string]any{
@@ -469,7 +469,7 @@ func TestProcessEvent(t *testing.T) {
 	})
 
 	t.Run("When event source is not post processed on API and it matches no charges", func(t *testing.T) {
-		processor, mockedStore, testProducers, _, delete := setupProcessorTestEnv(t)
+		processor, mockedStore, testProducers, _, _, delete := setupProcessorTestEnv(t)
 		defer delete()
 
 		properties := map[string]any{
@@ -514,5 +514,66 @@ func TestProcessEvent(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		assert.Equal(t, 1, testProducers.enrichedProducer.ExecutionCount)
 		assert.Equal(t, 0, testProducers.enrichedExpandedProducer.ExecutionCount)
+	})
+
+	t.Run("When reprocess flag is set, only produces to enriched expanded topic", func(t *testing.T) {
+		processor, mockedStore, testProducers, flagger, cacheStore, delete := setupProcessorTestEnv(t)
+		defer delete()
+
+		properties := map[string]any{
+			"api_requests": "12.0",
+		}
+
+		event := models.Event{
+			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			ExternalSubscriptionID: "sub_id",
+			Code:                   "api_calls",
+			Timestamp:              1741007009,
+			Properties:             properties,
+			Source:                 models.HTTP_RUBY,
+			SourceMetadata: &models.SourceMetadata{
+				ApiPostProcess: true,
+				Reprocess:      true,
+			},
+		}
+
+		bm := models.BillableMetric{
+			ID:              "bm123",
+			OrganizationID:  event.OrganizationID,
+			Code:            event.Code,
+			AggregationType: models.AggregationTypeSum,
+			FieldName:       "api_requests",
+			Expression:      "",
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+		mockBmLookup(mockedStore, &bm)
+
+		sub := models.Subscription{ID: "sub123", PlanID: "plan123"}
+		mockSubscriptionLookup(mockedStore, &sub)
+
+		now := time.Now()
+
+		mockFlatFiltersLookup(mockedStore, []*models.FlatFilter{
+			{
+				OrganizationID:     event.OrganizationID,
+				BillableMetricCode: event.Code,
+				PlanID:             "plan_id",
+				ChargeID:           "charge_id1",
+				ChargeUpdatedAt:    now,
+				PayInAdvance:       true,
+			},
+		})
+
+		result := processor.processEvent(context.Background(), &event)
+
+		assert.True(t, result.Success())
+		assert.Equal(t, "12.0", *result.Value().Value)
+
+		assert.Equal(t, 1, testProducers.enrichedExpandedProducer.ExecutionCount)
+		assert.Equal(t, 0, testProducers.enrichedProducer.ExecutionCount)
+		assert.Equal(t, 0, testProducers.inAdvanceProducer.ExecutionCount)
+		assert.Equal(t, 0, flagger.ExecutionCount)
+		assert.Equal(t, 0, cacheStore.ExecutionCount)
 	})
 }


### PR DESCRIPTION
## Context

Two issues where recently identified in the events-processor:
- Events with `timestamp` formatted as ISO 8601 string were not processed correctly and were pushed to the dead letter queue (fixed with https://github.com/getlago/lago/pull/709)
- Pricing group keys were not assigned correctly to the events when no filters were present on a given charge, leading to inconsistent data in the `events_enriched_expanded` kafka topic and clickhouse table (fixed with https://github.com/getlago/lago/pull/710)

Because of this two issues, some events will need to be reprocessed, either completely (for the timestamp issue as not `events_enriched` record were created), or partially (for the grouped_by issue as we only need to re-create the `events_enriched_expanded` record) 

## Description

This PR check for the presence of a new `reprocess` flag on the `event_raw` kafka payload. When present this flag will allow to completely by-pass some part of the pipeline like the `events_enriched` kafka message producing, the subscription flagging for refresh or the cache expiration. Only an `events_enriched_explanded` message will be produced