### PR TITLE
fix(subscription): Fix flagging for refresh

### DIFF
--- a/events-processor/go.mod
+++ b/events-processor/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/DataDog/dd-trace-go/v2 v2.4.0
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/getlago/lago-expression/expression-go v0.1.4
 	github.com/getsentry/sentry-go v0.40.0
 	github.com/jackc/pgx/v5 v5.7.6
@@ -91,6 +92,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/component v1.42.0 // indirect

--- a/events-processor/go.sum
+++ b/events-processor/go.sum
@@ -39,6 +39,8 @@ github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -213,6 +215,8 @@ github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgq
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/events-processor/models/stores.go
+++ b/events-processor/models/stores.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"time"
 
+	goredis "github.com/redis/go-redis/v9"
+
 	"github.com/getlago/lago/events-processor/config/database"
 	"github.com/getlago/lago/events-processor/config/redis"
 	"github.com/getlago/lago/events-processor/utils"
 )
 
-const EXPIRATION_TIME = 5 * time.Second
+const EXPIRATION_TIME = 15 * time.Second
+const CLICKHOUSE_MERGE_DELAY int64 = 15
 
 type ApiStore struct {
 	db *database.DB
@@ -40,8 +43,22 @@ func NewFlagStore(ctx context.Context, redis *redis.RedisDB, name string) *FlagS
 	}
 }
 
+// Flag adds a subscription to the sorted set for delayed refresh.
+// The member key includes a time bucket (value|bucket) so that events within
+// the same CLICKHOUSE_MERGE_DELAY window share a member — ZADD overwrites the
+// score to the latest event, waiting after the last event in that window.
+// Once the window elapses, new events create a new member, ensuring the
+// previous one ages out and gets picked up by the consumer (no starvation).
 func (store *FlagStore) Flag(value string) error {
-	result := store.db.Client.SAdd(store.context, store.name, fmt.Sprintf("%s", value))
+	now := time.Now().Unix()
+
+	// Calculate the bucket (time window) for the event
+	bucket := (now / CLICKHOUSE_MERGE_DELAY) * CLICKHOUSE_MERGE_DELAY
+
+	result := store.db.Client.ZAdd(store.context, store.name, goredis.Z{
+		Score:  float64(now),
+		Member: fmt.Sprintf("%s|%d", value, bucket),
+	})
 	if err := result.Err(); err != nil {
 		return err
 	}

--- a/events-processor/models/stores_test.go
+++ b/events-processor/models/stores_test.go
@@ -1,10 +1,18 @@
 package models
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
 
+	"github.com/getlago/lago/events-processor/config/redis"
 	"github.com/getlago/lago/events-processor/tests"
 )
 
@@ -16,4 +24,108 @@ func setupApiStore(t *testing.T) (*ApiStore, sqlmock.Sqlmock, func()) {
 	}
 
 	return store, mock.SQLMock, delete
+}
+
+func setupFlagStore(t *testing.T, name string) (*FlagStore, *miniredis.Miniredis) {
+	s := miniredis.RunT(t)
+	client := goredis.NewClient(&goredis.Options{Addr: s.Addr()})
+	store := &FlagStore{
+		name:    name,
+		context: context.Background(),
+		db:      &redis.RedisDB{Client: client},
+	}
+	return store, s
+}
+
+func TestFlag(t *testing.T) {
+	t.Run("adds member to sorted set with correct format", func(t *testing.T) {
+		store, s := setupFlagStore(t, "test_flags")
+
+		err := store.Flag("org1:sub1")
+		assert.NoError(t, err)
+
+		members, err := s.ZMembers("test_flags")
+		assert.NoError(t, err)
+		assert.Len(t, members, 1)
+
+		// Member should be "org1:sub1|<bucket>"
+		assert.True(t, strings.HasPrefix(members[0], "org1:sub1|"))
+
+		// Score should be close to current time
+		score, err := s.ZScore("test_flags", members[0])
+		assert.NoError(t, err)
+		assert.InDelta(t, float64(time.Now().Unix()), score, 2)
+	})
+
+	t.Run("bucket follows CLICKHOUSE_MERGE_DELAY intervals", func(t *testing.T) {
+		store, s := setupFlagStore(t, "test_flags")
+
+		err := store.Flag("org1:sub1")
+		assert.NoError(t, err)
+
+		members, err := s.ZMembers("test_flags")
+		assert.NoError(t, err)
+
+		parts := strings.Split(members[0], "|")
+		assert.Len(t, parts, 2)
+
+		now := time.Now().Unix()
+		expectedBucket := (now / CLICKHOUSE_MERGE_DELAY) * CLICKHOUSE_MERGE_DELAY
+		assert.Equal(t, fmt.Sprintf("%d", expectedBucket), parts[1])
+	})
+
+	t.Run("two calls in same window produce one member", func(t *testing.T) {
+		store, s := setupFlagStore(t, "test_flags")
+
+		err := store.Flag("org1:sub1")
+		assert.NoError(t, err)
+		err = store.Flag("org1:sub1")
+		assert.NoError(t, err)
+
+		members, err := s.ZMembers("test_flags")
+		assert.NoError(t, err)
+		assert.Len(t, members, 1)
+	})
+
+	t.Run("different values produce separate members", func(t *testing.T) {
+		store, s := setupFlagStore(t, "test_flags")
+
+		err := store.Flag("org1:sub1")
+		assert.NoError(t, err)
+		err = store.Flag("org2:sub2")
+		assert.NoError(t, err)
+
+		members, err := s.ZMembers("test_flags")
+		assert.NoError(t, err)
+		assert.Len(t, members, 2)
+	})
+
+	t.Run("new bucket after time window advances", func(t *testing.T) {
+		store, s := setupFlagStore(t, "test_flags")
+
+		err := store.Flag("org1:sub1")
+		assert.NoError(t, err)
+
+		// Fast-forward miniredis past the merge delay window
+		s.FastForward(time.Duration(CLICKHOUSE_MERGE_DELAY+1) * time.Second)
+		// The bucket is computed from time.Now(), so we can't truly advance real time.
+		// Instead, we verify that if two different buckets are used, two members exist.
+		// Manually add a member with a different bucket to simulate the scenario.
+		now := time.Now().Unix()
+		differentBucket := ((now / CLICKHOUSE_MERGE_DELAY) + 1) * CLICKHOUSE_MERGE_DELAY
+		s.ZAdd("test_flags", float64(now), fmt.Sprintf("org1:sub1|%d", differentBucket))
+
+		members, err := s.ZMembers("test_flags")
+		assert.NoError(t, err)
+		assert.Len(t, members, 2)
+	})
+
+	t.Run("returns error on redis failure", func(t *testing.T) {
+		store, s := setupFlagStore(t, "test_flags")
+
+		s.SetError("forced error")
+		err := store.Flag("org1:sub1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "forced error")
+	})
 }

--- a/events-processor/processors/main_processor.go
+++ b/events-processor/processors/main_processor.go
@@ -177,7 +177,7 @@ func StartProcessingEvents(ctx context.Context, config *Config) {
 	apiStore = models.NewApiStore(db)
 	defer db.Close()
 
-	flagger, err := initFlagStore(ctx, "subscription_refreshed")
+	flagger, err := initFlagStore(ctx, "subscription_refreshed_v2")
 	if err != nil {
 		utils.LogAndPanic(err, "Error connecting to the flag store")
 	}

--- a/events-processor/utils/time_test.go
+++ b/events-processor/utils/time_test.go
@@ -84,6 +84,10 @@ func TestToFloat64Timestamp(t *testing.T) {
 				parsedValue: 1741007009.344,
 			},
 			expectedTime64{
+				timestamp:   "1741007009.000001",
+				parsedValue: 1741007009.000,
+			},
+			expectedTime64{
 				timestamp:   "2025-03-03T13:03:29Z",
 				parsedValue: 1741007009.0,
 			},


### PR DESCRIPTION
## Context

When the events-processor processes an event, it pushes it to ClickHouse (via Kafka) and immediately flags the subscription for refresh in a Redis SET. The Ruby API consumes this set every minute and triggers a refresh job. The race condition: ClickHouse may not have merged the new events by the time the refresh job queries it, causing stale aggregation values to be cached indefinitely (until the next event).

The current 5-second Sidekiq delay (`REFRESH_WAIT_TIME`) on the Ruby side was designed to outlast the cache TTL, not ClickHouse merge latency. We need a delay linked to **event processing time**, not to clock pickup time.

## Description

This PR changes the queuing approach from a Redis SET to a sorted SET with a bucketed approach.

- On the producer side:
New events will flag subscription with a timestamp based score. Every events received for the same subscription within a 15s window, will reset the score. New events received outside the 15 seconds window, will flag the subscription in a new bucket, avoiding a "starvation" issue for subscription continuously receiving events.

- On the consumer side (https://github.com/getlago/lago-api/pull/5230):
The process will consume the eligible messages (older than 15 seconds) ordering them by score, ensuring that higher score (older messages) will be consumed first.