### PR TITLE
misc(events-processor): Reduce cashing expiration and flagging delay

### DIFF
--- a/events-processor/models/stores.go
+++ b/events-processor/models/stores.go
@@ -12,8 +12,8 @@ import (
 	"github.com/getlago/lago/events-processor/utils"
 )
 
-const EXPIRATION_TIME = 15 * time.Second
-const CLICKHOUSE_MERGE_DELAY int64 = 15
+const EXPIRATION_TIME = 10 * time.Second
+const SUBSCRIPTION_BUCKET_DURATION int64 = 10
 
 type ApiStore struct {
 	db *database.DB
@@ -45,7 +45,7 @@ func NewFlagStore(ctx context.Context, redis *redis.RedisDB, name string) *FlagS
 
 // Flag adds a subscription to the sorted set for delayed refresh.
 // The member key includes a time bucket (value|bucket) so that events within
-// the same CLICKHOUSE_MERGE_DELAY window share a member — ZADD overwrites the
+// the same SUBSCRIPTION_BUCKET_DURATION window share a member — ZADD overwrites the
 // score to the latest event, waiting after the last event in that window.
 // Once the window elapses, new events create a new member, ensuring the
 // previous one ages out and gets picked up by the consumer (no starvation).
@@ -53,7 +53,7 @@ func (store *FlagStore) Flag(value string) error {
 	now := time.Now().Unix()
 
 	// Calculate the bucket (time window) for the event
-	bucket := (now / CLICKHOUSE_MERGE_DELAY) * CLICKHOUSE_MERGE_DELAY
+	bucket := (now / SUBSCRIPTION_BUCKET_DURATION) * SUBSCRIPTION_BUCKET_DURATION
 
 	result := store.db.Client.ZAdd(store.context, store.name, goredis.Z{
 		Score:  float64(now),

--- a/events-processor/models/stores_test.go
+++ b/events-processor/models/stores_test.go
@@ -57,7 +57,7 @@ func TestFlag(t *testing.T) {
 		assert.InDelta(t, float64(time.Now().Unix()), score, 2)
 	})
 
-	t.Run("bucket follows CLICKHOUSE_MERGE_DELAY intervals", func(t *testing.T) {
+	t.Run("bucket follows SUBSCRIPTION_BUCKET_DURATION intervals", func(t *testing.T) {
 		store, s := setupFlagStore(t, "test_flags")
 
 		err := store.Flag("org1:sub1")
@@ -70,7 +70,7 @@ func TestFlag(t *testing.T) {
 		assert.Len(t, parts, 2)
 
 		now := time.Now().Unix()
-		expectedBucket := (now / CLICKHOUSE_MERGE_DELAY) * CLICKHOUSE_MERGE_DELAY
+		expectedBucket := (now / SUBSCRIPTION_BUCKET_DURATION) * SUBSCRIPTION_BUCKET_DURATION
 		assert.Equal(t, fmt.Sprintf("%d", expectedBucket), parts[1])
 	})
 
@@ -107,12 +107,12 @@ func TestFlag(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Fast-forward miniredis past the merge delay window
-		s.FastForward(time.Duration(CLICKHOUSE_MERGE_DELAY+1) * time.Second)
+		s.FastForward(time.Duration(SUBSCRIPTION_BUCKET_DURATION+1) * time.Second)
 		// The bucket is computed from time.Now(), so we can't truly advance real time.
 		// Instead, we verify that if two different buckets are used, two members exist.
 		// Manually add a member with a different bucket to simulate the scenario.
 		now := time.Now().Unix()
-		differentBucket := ((now / CLICKHOUSE_MERGE_DELAY) + 1) * CLICKHOUSE_MERGE_DELAY
+		differentBucket := ((now / SUBSCRIPTION_BUCKET_DURATION) + 1) * SUBSCRIPTION_BUCKET_DURATION
 		s.ZAdd("test_flags", float64(now), fmt.Sprintf("org1:sub1|%d", differentBucket))
 
 		members, err := s.ZMembers("test_flags")


### PR DESCRIPTION
## Description

This PR reduces the cache expiration delay and the subscription refresh bucket duration from 15 seconds to 10.
The main goal is to get closer to "realtime" wallet refresh and alerting.

The `CLICKHOUSE_MERGE_DELAY` is renamed into `SUBSCRIPTION_BUCKET_DURATION` to better reflect its purpose.