### PR TITLE
fix(events-processor): Fix producer keys limits

### DIFF
--- a/events-processor/processors/events_processor/event_producer_service.go
+++ b/events-processor/processors/events_processor/event_producer_service.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"sort"
 	"time"
 
 	"github.com/getlago/lago/events-processor/config/kafka"
@@ -41,20 +40,6 @@ func (eps *EventProducerService) ProduceEnrichedEvent(context context.Context, e
 }
 
 func (eps *EventProducerService) ProduceEnrichedExpandedEvent(context context.Context, event *models.EnrichedEvent) {
-	groupedBy := ""
-	groupKeys := make([]string, 0, len(event.GroupedBy))
-	for key := range event.GroupedBy {
-		groupKeys = append(groupKeys, key)
-	}
-	sort.Strings(groupKeys)
-
-	for _, key := range groupKeys {
-		if groupedBy != "" {
-			groupedBy += "|"
-		}
-		groupedBy += fmt.Sprintf("%s/%s", key, event.GroupedBy[key])
-	}
-
 	msgKey := fmt.Sprintf("%s-%s", event.OrganizationID, event.TransactionID)
 
 	err := eps.produceEvent(context, event, msgKey, eps.enrichedExpendedProducer)

--- a/events-processor/processors/events_processor/event_producer_service.go
+++ b/events-processor/processors/events_processor/event_producer_service.go
@@ -30,7 +30,7 @@ func NewEventProducerService(enrichedProducer, enrichedExpendedProducer, inAdvan
 }
 
 func (eps *EventProducerService) ProduceEnrichedEvent(context context.Context, event *models.EnrichedEvent) {
-	msgKey := fmt.Sprintf("%s-%s-%s", event.OrganizationID, event.ExternalSubscriptionID, event.Code)
+	msgKey := fmt.Sprintf("%s-%s", event.OrganizationID, event.TransactionID)
 
 	err := eps.produceEvent(context, event, msgKey, eps.enrichedProducer)
 
@@ -41,16 +41,6 @@ func (eps *EventProducerService) ProduceEnrichedEvent(context context.Context, e
 }
 
 func (eps *EventProducerService) ProduceEnrichedExpandedEvent(context context.Context, event *models.EnrichedEvent) {
-	chargeID := ""
-	if event.ChargeID != nil {
-		chargeID = *event.ChargeID
-	}
-
-	chargeFilterID := ""
-	if event.ChargeFilterID != nil {
-		chargeFilterID = *event.ChargeFilterID
-	}
-
 	groupedBy := ""
 	groupKeys := make([]string, 0, len(event.GroupedBy))
 	for key := range event.GroupedBy {
@@ -65,7 +55,7 @@ func (eps *EventProducerService) ProduceEnrichedExpandedEvent(context context.Co
 		groupedBy += fmt.Sprintf("%s/%s", key, event.GroupedBy[key])
 	}
 
-	msgKey := fmt.Sprintf("%s-%s-%s-%s-%s-%s", event.OrganizationID, event.ExternalSubscriptionID, event.Code, chargeID, chargeFilterID, groupedBy)
+	msgKey := fmt.Sprintf("%s-%s", event.OrganizationID, event.TransactionID)
 
 	err := eps.produceEvent(context, event, msgKey, eps.enrichedExpendedProducer)
 	if err != nil {
@@ -75,7 +65,7 @@ func (eps *EventProducerService) ProduceEnrichedExpandedEvent(context context.Co
 }
 
 func (eps *EventProducerService) ProduceChargedInAdvanceEvent(context context.Context, event *models.EnrichedEvent) {
-	msgKey := fmt.Sprintf("%s-%s-%s", event.OrganizationID, event.ExternalSubscriptionID, event.Code)
+	msgKey := fmt.Sprintf("%s-%s", event.OrganizationID, event.TransactionID)
 
 	err := eps.produceEvent(context, event, msgKey, eps.inAdvanceProducer)
 

--- a/events-processor/processors/events_processor/event_producer_service_test.go
+++ b/events-processor/processors/events_processor/event_producer_service_test.go
@@ -42,6 +42,7 @@ func TestProduceEnrichedEvent(t *testing.T) {
 		OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
 		ExternalSubscriptionID: "sub_id",
 		Code:                   "api_calls",
+		TransactionID:          "transaction_id",
 	}
 
 	producerService.ProduceEnrichedEvent(context.Background(), &event)
@@ -49,7 +50,7 @@ func TestProduceEnrichedEvent(t *testing.T) {
 	assert.Equal(t, 1, enrichedProducer.ExecutionCount)
 	assert.Equal(
 		t,
-		[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-sub_id-api_calls"),
+		[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-transaction_id"),
 		enrichedProducer.Key,
 	)
 
@@ -65,6 +66,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 			OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
 			ExternalSubscriptionID: "sub_id",
 			Code:                   "api_calls",
+			TransactionID:          "transaction_id",
 		}
 
 		producerService.ProduceEnrichedExpandedEvent(context.Background(), &event)
@@ -72,7 +74,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 		assert.Equal(t, 1, enrichedExpandedProducer.ExecutionCount)
 		assert.Equal(
 			t,
-			[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-sub_id-api_calls---"),
+			[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-transaction_id"),
 			enrichedExpandedProducer.Key,
 		)
 
@@ -88,6 +90,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 			ExternalSubscriptionID: "sub_id",
 			Code:                   "api_calls",
 			ChargeID:               utils.StringPtr("charge_id"),
+			TransactionID:          "transaction_id",
 		}
 
 		producerService.ProduceEnrichedExpandedEvent(context.Background(), &event)
@@ -95,7 +98,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 		assert.Equal(t, 1, enrichedExpandedProducer.ExecutionCount)
 		assert.Equal(
 			t,
-			[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-sub_id-api_calls-charge_id--"),
+			[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-transaction_id"),
 			enrichedExpandedProducer.Key,
 		)
 
@@ -111,6 +114,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 			ExternalSubscriptionID: "sub_id",
 			Code:                   "api_calls",
 			ChargeFilterID:         utils.StringPtr("charge_filter_id"),
+			TransactionID:          "transaction_id",
 		}
 
 		producerService.ProduceEnrichedExpandedEvent(context.Background(), &event)
@@ -118,7 +122,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 		assert.Equal(t, 1, enrichedExpandedProducer.ExecutionCount)
 		assert.Equal(
 			t,
-			[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-sub_id-api_calls--charge_filter_id-"),
+			[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-transaction_id"),
 			enrichedExpandedProducer.Key,
 		)
 
@@ -134,6 +138,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 			ExternalSubscriptionID: "sub_id",
 			Code:                   "api_calls",
 			GroupedBy:              map[string]string{"country": "US", "type": "debit"},
+			TransactionID:          "transaction_id",
 		}
 
 		producerService.ProduceEnrichedExpandedEvent(context.Background(), &event)
@@ -141,7 +146,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 		assert.Equal(t, 1, enrichedExpandedProducer.ExecutionCount)
 		assert.Equal(
 			t,
-			[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-sub_id-api_calls---country/US|type/debit"),
+			[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-transaction_id"),
 			enrichedExpandedProducer.Key,
 		)
 
@@ -157,6 +162,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 			ExternalSubscriptionID: "sub_id",
 			Code:                   "api_calls",
 			GroupedBy:              map[string]string{"type": "debit", "country": "US"},
+			TransactionID:          "transaction_id",
 		}
 
 		producerService.ProduceEnrichedExpandedEvent(context.Background(), &event)
@@ -164,7 +170,7 @@ func TestProduceEnrichedExtendedEvent(t *testing.T) {
 		assert.Equal(t, 1, enrichedExpandedProducer.ExecutionCount)
 		assert.Equal(
 			t,
-			[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-sub_id-api_calls---country/US|type/debit"),
+			[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-transaction_id"),
 			enrichedExpandedProducer.Key,
 		)
 
@@ -180,6 +186,7 @@ func TestProduceChargedInAdvanceEvent(t *testing.T) {
 		OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
 		ExternalSubscriptionID: "sub_id",
 		Code:                   "api_calls",
+		TransactionID:          "transaction_id",
 	}
 
 	producerService.ProduceChargedInAdvanceEvent(context.Background(), &event)
@@ -187,7 +194,7 @@ func TestProduceChargedInAdvanceEvent(t *testing.T) {
 	assert.Equal(t, 1, inAdvanceProducer.ExecutionCount)
 	assert.Equal(
 		t,
-		[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-sub_id-api_calls"),
+		[]byte("1a901a90-1a90-1a90-1a90-1a901a901a90-transaction_id"),
 		inAdvanceProducer.Key,
 	)
 
@@ -202,6 +209,7 @@ func TestProduceToDeadLetterQueue(t *testing.T) {
 		OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
 		ExternalSubscriptionID: "sub_id",
 		Code:                   "api_calls",
+		TransactionID:          "transaction_id",
 	}
 
 	result := utils.FailedResult[string](fmt.Errorf("Error Message"))


### PR DESCRIPTION
Today we are using a key for kafka message that is not scalable.
eg: if an org have a lot of events on the same subscription, it will be produced on the same partition, this can cause consumer (assuming we have 1 consumer per partition) bloat.
It's better to use a kind of uniq key (organization_id-transaction_id) so the load is spread on all partitions, making it easier to scale.

This limitations appeared during some load testing (100 partitions / 100 events processor) with a small number of active subscriptions. Load was only on some consumers.

No impact on the current prod logic, it will just spread the load around existing partitions.