### PR TITLE
fix(events-processor): Skip kafka commit when no record is commitable

### DIFF
--- a/events-processor/config/kafka/consumer.go
+++ b/events-processor/config/kafka/consumer.go
@@ -91,7 +91,13 @@ func (pc *PartitionConsumer) processRecordsAndCommit(records []*kgo.Record) {
 
 	if len(processedRecords) != len(records) {
 		// Ensure we are not committing records that were not processed and can be re-consumed
-		record := findMaxCommitableRecord(processedRecords, records)
+		record, ok := findMaxCommitableRecord(processedRecords, records)
+		if !ok {
+			// No record in the batch is safe to commit (e.g. the first record failed).
+			// Skip the commit; records will be re-polled after the next rebalance.
+			pc.logger.Warn(fmt.Sprintf("No commitable record in batch, skipping commit. topic: %s partition: %d batch_size: %d processed: %d\n", pc.topic, pc.partition, len(records), len(processedRecords)))
+			return
+		}
 		commitableRecords = []*kgo.Record{record}
 	}
 
@@ -265,7 +271,11 @@ func (cg *ConsumerGroup) Start(ctx context.Context) {
 	cg.logger.Info("Consumer group shutdown is complete")
 }
 
-func findMaxCommitableRecord(processedRecords []*kgo.Record, records []*kgo.Record) *kgo.Record {
+// findMaxCommitableRecord returns the highest-offset processed record that is
+// strictly below the lowest-offset unprocessed record — i.e. the largest
+// commitable prefix of the batch. ok is false when no such record exists
+// (typically because the first record of the batch was not processed).
+func findMaxCommitableRecord(processedRecords []*kgo.Record, records []*kgo.Record) (*kgo.Record, bool) {
 	// Keep track of processed records
 	processedMap := make(map[string]bool)
 	for _, record := range processedRecords {
@@ -294,5 +304,5 @@ func findMaxCommitableRecord(processedRecords []*kgo.Record, records []*kgo.Reco
 		}
 	}
 
-	return maxRecord
+	return maxRecord, maxRecord != nil
 }

--- a/events-processor/config/kafka/consumer_test.go
+++ b/events-processor/config/kafka/consumer_test.go
@@ -108,11 +108,13 @@ func TestFindMaxCommitableRecord(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				result := findMaxCommitableRecord(test.processedRecords, test.records)
+				result, ok := findMaxCommitableRecord(test.processedRecords, test.records)
 
 				if test.expected == nil {
 					assert.Nil(t, result)
+					assert.False(t, ok)
 				} else {
+					assert.True(t, ok)
 					assert.NotNil(t, result)
 					assert.Equal(t, test.expected.Key, result.Key)
 					assert.Equal(t, test.expected.Offset, result.Offset)

--- a/events-processor/models/subscriptions.go
+++ b/events-processor/models/subscriptions.go
@@ -1,9 +1,11 @@
 package models
 
 import (
+	"sync"
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
 
 	"github.com/getlago/lago/events-processor/utils"
 )
@@ -19,6 +21,8 @@ type Subscription struct {
 	TerminatedAt   utils.NullTime `gorm:"->" json:"terminated_at"`
 }
 
+var subscriptionSchema, _ = schema.Parse(&Subscription{}, &sync.Map{}, schema.NamingStrategy{})
+
 func (store *ApiStore) FetchSubscription(organizationID string, externalID string, timestamp time.Time) utils.Result[*Subscription] {
 	var sub Subscription
 
@@ -30,6 +34,7 @@ func (store *ApiStore) FetchSubscription(organizationID string, externalID strin
 	`
 	result := store.db.Connection.
 		Table("subscriptions").
+		Select(subscriptionSchema.DBNames).
 		Unscoped().
 		Where(conditions, organizationID, externalID, timestamp, timestamp).
 		Order("terminated_at DESC NULLS FIRST, started_at DESC").

--- a/events-processor/models/subscriptions_test.go
+++ b/events-processor/models/subscriptions_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var fetchSubscriptionQuery = regexp.QuoteMeta(`
-	SELECT *
+	SELECT "id","organization_id","external_id","plan_id","created_at","updated_at","started_at","terminated_at"
 	FROM "subscriptions"
 	WHERE subscriptions.organization_id = $1
 		AND subscriptions.external_id = $2
@@ -32,9 +32,9 @@ func TestFetchSubscription(t *testing.T) {
 		timestamp := time.Now()
 
 		// Define expected rows and columns
-		columns := []string{"id", "external_id", "plan_id", "created_at", "updated_at", "started_at", "terminated_at"}
+		columns := []string{"id", "organization_id", "external_id", "plan_id", "created_at", "updated_at", "started_at", "terminated_at"}
 		rows := sqlmock.NewRows(columns).
-			AddRow("sub123", externalID, "plan123", timestamp, timestamp, timestamp, timestamp)
+			AddRow("sub123", orgID, externalID, "plan123", timestamp, timestamp, timestamp, timestamp)
 
 		// Expect the query
 		mock.ExpectQuery(fetchSubscriptionQuery).


### PR DESCRIPTION
## Problem

The events-processor pod crashes (SIGSEGV) every time the API ships a migration that alters `subscriptions`. Two latent bugs compose:

1. pgx's default `QueryExecModeCacheStatement` caches prepared plans per connection, and `FetchSubscription` runs `SELECT *` — so any column change invalidates every cached plan with `SQLSTATE 0A000`.
2. When that error hits the first record of a Kafka batch, `findMaxCommitableRecord` returns `nil`; the caller wraps it in a slice and hands it to franz-go's `CommitRecords`, which dereferences a `nil` pointer and crashes the pod.

## Changes

- **Skip commit when no record is commitable** (`config/kafka/consumer.go`): `findMaxCommitableRecord` now returns `(*kgo.Record, bool)`. The caller checks the bool and skips `CommitRecords` entirely when there's no commitable prefix. Stops the crash regardless of trigger.
- **Select explicit columns in `FetchSubscription`** (`models/subscriptions.go`): the column list is derived from the `Subscription` struct via `schema.Parse` and pinned to `.Select(...)`. Adding a column on the table no longer changes the result type, so the cached plan stays valid. Tests fail loudly if the struct changes, keeping SELECT and struct in sync.
