### PR TITLE
fix: parse quoted PostgreSQL string arrays

### DIFF
--- a/events-processor/utils/string.go
+++ b/events-processor/utils/string.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 type StringArray []string
@@ -52,21 +53,56 @@ func parsePostgresArray(s string) []string {
 		return []string{}
 	}
 
-	// Remove curly braces
-	s = strings.TrimPrefix(s, "{")
-	s = strings.TrimSuffix(s, "}")
+	if !strings.HasPrefix(s, "{") || !strings.HasSuffix(s, "}") {
+		return []string{strings.Trim(s, "\"")}
+	}
 
-	// Split by comma and clean up quotes
-	parts := strings.Split(s, ",")
-	result := make([]string, 0, len(parts))
+	s = strings.TrimSuffix(strings.TrimPrefix(s, "{"), "}")
+	result := make([]string, 0)
+	var current strings.Builder
+	inQuotes := false
+	escaped := false
+	quoted := false
+	tokenStarted := false
 
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		part = strings.Trim(part, "\"")
-		if part != "" {
-			result = append(result, part)
+	appendValue := func() {
+		value := current.String()
+		if !quoted {
+			value = strings.TrimSpace(value)
+		}
+		if quoted || value != "" {
+			result = append(result, value)
+		}
+		current.Reset()
+		quoted = false
+		tokenStarted = false
+	}
+
+	for _, char := range s {
+		switch {
+		case escaped:
+			current.WriteRune(char)
+			escaped = false
+			tokenStarted = true
+		case char == '\\' && inQuotes:
+			escaped = true
+		case char == '"':
+			inQuotes = !inQuotes
+			quoted = true
+			tokenStarted = true
+		case char == ',' && !inQuotes:
+			appendValue()
+		case !inQuotes && quoted && unicode.IsSpace(char):
+			continue
+		case !inQuotes && !tokenStarted && unicode.IsSpace(char):
+			continue
+		default:
+			current.WriteRune(char)
+			tokenStarted = true
 		}
 	}
+
+	appendValue()
 
 	return result
 }

--- a/events-processor/utils/string_test.go
+++ b/events-processor/utils/string_test.go
@@ -102,6 +102,18 @@ func TestStringArray_Scan(t *testing.T) {
 			expected: StringArray{"plain string"},
 			wantErr:  false,
 		},
+		{
+			name:     "postgres array with quoted comma",
+			input:    `{"value,1","value2"}`,
+			expected: StringArray{"value,1", "value2"},
+			wantErr:  false,
+		},
+		{
+			name:     "postgres array with empty string",
+			input:    `{"","value2"}`,
+			expected: StringArray{"", "value2"},
+			wantErr:  false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## what
Fix `StringArray` PostgreSQL array fallback parsing.

Quoted commas now stay inside the value. Quoted empty strings are kept too. Small edge case, but yeah, the old split-on-comma path was kinda rough.

## repro
Before this patch, these valid PostgreSQL array values parsed wrong:

```go
`{"value,1","value2"}` // became ["value", "1", "value2"]
`{"","value2"}`       // became ["value2"]
```

The new regression cases show it:

```sh
go test ./utils -run TestStringArray_Scan
```

## checks
- `go test ./utils -run TestStringArray`
- `go test ./cache ./models ./utils ./config/kafka`

No linked issue found. Searched issues and PRs for `StringArray`, `PostgreSQL array`, and `events-processor`.
