### PR TITLE
[ING-123] fix(events-processor): Add organization_id in fetch flat filters query

### DIFF
--- a/events-processor/models/flat_filters.go
+++ b/events-processor/models/flat_filters.go
@@ -97,10 +97,16 @@ type FlatFilter struct {
 	AcceptsTargetWallet   bool              `gorm:"type:boolean"`
 }
 
-func (store *ApiStore) FetchFlatFilters(planID string, billableMetricCode string) utils.Result[[]*FlatFilter] {
+func (store *ApiStore) FetchFlatFilters(organizationID string, planID string, billableMetricCode string) utils.Result[[]*FlatFilter] {
 	var filters []*FlatFilter
 
-	result := store.db.Connection.Find(&filters, "plan_id = ? AND billable_metric_code = ?", planID, billableMetricCode)
+	result := store.db.Connection.Find(
+		&filters,
+		"organization_id = ? AND plan_id = ? AND billable_metric_code = ?",
+		organizationID,
+		planID,
+		billableMetricCode,
+	)
 	if result.Error != nil {
 		return utils.FailedResult[[]*FlatFilter](result.Error)
 	}

--- a/events-processor/models/flat_filters_test.go
+++ b/events-processor/models/flat_filters_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var fetchFiltersQuery = regexp.QuoteMeta(`
-	SELECT * FROM "flat_filters" WHERE plan_id = $1 AND billable_metric_code = $2`)
+	SELECT * FROM "flat_filters" WHERE organization_id = $1 AND plan_id = $2 AND billable_metric_code = $3`)
 
 func TestFetchFlatFilters(t *testing.T) {
 	t.Run("should return flat filters when found", func(t *testing.T) {
@@ -20,6 +20,7 @@ func TestFetchFlatFilters(t *testing.T) {
 		defer cleanup()
 
 		code := "api_calls"
+		organizationID := "1a901a90-1a90-1a90-1a90-1a901a901a90"
 		planID := "1a901a90-1a90-1a90-1a90-1a901a901a90"
 		now := time.Now()
 
@@ -50,7 +51,7 @@ func TestFetchFlatFilters(t *testing.T) {
 		}
 		rows := sqlmock.NewRows(columns).
 			AddRow(
-				"1a901a90-1a90-1a90-1a90-1a901a901a90",
+				organizationID,
 				code,
 				planID,
 				"1a901a90-1a90-1a90-1a90-1a901a901a90",
@@ -65,10 +66,10 @@ func TestFetchFlatFilters(t *testing.T) {
 
 		// Expect the query
 		mock.ExpectQuery(fetchFiltersQuery).
-			WithArgs(planID, code).
+			WithArgs(organizationID, planID, code).
 			WillReturnRows(rows)
 
-		result := store.FetchFlatFilters(planID, code)
+		result := store.FetchFlatFilters(organizationID, planID, code)
 
 		// Assert
 		assert.True(t, result.Success())
@@ -92,6 +93,7 @@ func TestFetchFlatFilters(t *testing.T) {
 		defer cleanup()
 
 		code := "api_calls"
+		organizationID := "1a901a90-1a90-1a90-1a90-1a901a901a90"
 		planID := "1a901a90-1a90-1a90-1a90-1a901a901a90"
 
 		// Define expected rows and columns
@@ -112,10 +114,10 @@ func TestFetchFlatFilters(t *testing.T) {
 
 		// Expect the query
 		mock.ExpectQuery(fetchFiltersQuery).
-			WithArgs(planID, code).
+			WithArgs(organizationID, planID, code).
 			WillReturnRows(rows)
 
-		result := store.FetchFlatFilters(planID, code)
+		result := store.FetchFlatFilters(organizationID, planID, code)
 
 		// Assert
 		assert.True(t, result.Success())

--- a/events-processor/processors/events_processor/enrichment_service.go
+++ b/events-processor/processors/events_processor/enrichment_service.go
@@ -136,7 +136,7 @@ func (s *EventEnrichmentService) enrichWithChargeInfo(enrichedEvent *models.Enri
 	if s.memCache != nil {
 		filtersResult = s.memCache.BuildFlatFilters(enrichedEvent.OrganizationID, enrichedEvent.Code, enrichedEvent.PlanID)
 	} else {
-		filtersResult = s.apiStore.FetchFlatFilters(enrichedEvent.PlanID, enrichedEvent.Code)
+		filtersResult = s.apiStore.FetchFlatFilters(enrichedEvent.OrganizationID, enrichedEvent.PlanID, enrichedEvent.Code)
 	}
 	if filtersResult.Failure() {
 		return utils.FailedResult[[]*models.EnrichedEvent](filtersResult.Error())


### PR DESCRIPTION
# Context

After some analysis, it appears that the queries used in the events-processor to fetch the flat_filters (aggregated filter keys/values) is not performant enough under heavy write load on the database.

After some analysis, it appears that the queries made on the `flat_filters` view does not uses the correct index on the billable metric table (organization_id, code) when performing the lookup because the `organization_id` filter is not used in the query, leading to a Seq Scan instead of an Index Scan on the billable metric relation

## Description

This PR updates the query and the processing logic to use the organization_id value in conjunction with the actual `plan_id` and billable metric `code`