### PR TITLE
[ING-143] fix(events-processor): Pin flat_filters SELECT columns

### DIFF
--- a/events-processor/models/flat_filters.go
+++ b/events-processor/models/flat_filters.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"sync"
 	"time"
+
+	"gorm.io/gorm/schema"
 
 	"github.com/getlago/lago/events-processor/utils"
 )
@@ -97,16 +100,21 @@ type FlatFilter struct {
 	AcceptsTargetWallet   bool              `gorm:"type:boolean"`
 }
 
+var flatFilterSchema, _ = schema.Parse(&FlatFilter{}, &sync.Map{}, schema.NamingStrategy{})
+
 func (store *ApiStore) FetchFlatFilters(organizationID string, planID string, billableMetricCode string) utils.Result[[]*FlatFilter] {
 	var filters []*FlatFilter
 
-	result := store.db.Connection.Find(
-		&filters,
-		"organization_id = ? AND plan_id = ? AND billable_metric_code = ?",
-		organizationID,
-		planID,
-		billableMetricCode,
-	)
+	result := store.db.Connection.
+		Table("flat_filters").
+		Select(flatFilterSchema.DBNames).
+		Where(
+			"organization_id = ? AND plan_id = ? AND billable_metric_code = ?",
+			organizationID,
+			planID,
+			billableMetricCode,
+		).
+		Find(&filters)
 	if result.Error != nil {
 		return utils.FailedResult[[]*FlatFilter](result.Error)
 	}

--- a/events-processor/models/flat_filters_test.go
+++ b/events-processor/models/flat_filters_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 var fetchFiltersQuery = regexp.QuoteMeta(`
-	SELECT * FROM "flat_filters" WHERE organization_id = $1 AND plan_id = $2 AND billable_metric_code = $3`)
+	SELECT "organization_id","billable_metric_code","plan_id","charge_id","charge_updated_at","charge_filter_id","charge_filter_updated_at","filters","pricing_group_keys","pay_in_advance","accepts_target_wallet"
+	FROM "flat_filters"
+	WHERE organization_id = $1 AND plan_id = $2 AND billable_metric_code = $3`)
 
 func TestFetchFlatFilters(t *testing.T) {
 	t.Run("should return flat filters when found", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Same fix as #735 applied to `FetchFlatFilters`: derive the column list from the `FlatFilter` struct via `schema.Parse` and pin it with `.Select(...)`, so a `flat_filters` view alter no longer invalidates pgx's cached prepared plans (SQLSTATE 0A000) and crashes the pods.