### PR TITLE
chore: enable redis DEBUG command in dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -58,12 +58,11 @@ services:
     container_name: lago_redis_dev
     restart: unless-stopped
     command:
-      [
-        "sh",
-        "-c",
-        "redis-server --enable-debug-command local
-          $${REDIS_PASSWORD:+--requirepass \"$$REDIS_PASSWORD\"}",
-      ]
+      - sh
+      - -c
+      - >
+          redis-server --enable-debug-command local
+          $${REDIS_PASSWORD:+--requirepass "$$REDIS_PASSWORD"}
     env_file:
       - path: ./.env.development.default
       - path: ./.env.development

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,7 +57,13 @@ services:
     image: redis:7-alpine
     container_name: lago_redis_dev
     restart: unless-stopped
-    command: ["sh", "-c", "redis-server $${REDIS_PASSWORD:+--requirepass \"$$REDIS_PASSWORD\"}"]
+    command:
+      [
+        "sh",
+        "-c",
+        "redis-server --enable-debug-command local
+          $${REDIS_PASSWORD:+--requirepass \"$$REDIS_PASSWORD\"}",
+      ]
     env_file:
       - path: ./.env.development.default
       - path: ./.env.development


### PR DESCRIPTION
## Context

The Redis `DEBUG` command is disabled by default in recent Redis versions, which blocks local debugging workflows that rely on it (e.g. `DEBUG SLEEP`). These can be used for instance to easily test timeouts.

## Description

The dev Redis service now starts with `--enable-debug-command local`, allowing DEBUG commands from local connections. The command was reformatted across multiple lines for readability.
