### PR TITLE
Retry unresolved usage events before DLQ

### DIFF
--- a/events-processor/models/event.go
+++ b/events-processor/models/event.go
@@ -61,11 +61,21 @@ type EnrichedEvent struct {
 }
 
 type FailedEvent struct {
-	Event               Event     `json:"event"`
-	InitialErrorMessage string    `json:"initial_error_message"`
-	ErrorMessage        string    `json:"error_message"`
-	ErrorCode           string    `json:"error_code"`
-	FailedAt            time.Time `json:"failed_at"`
+	Event                  Event      `json:"event"`
+	InitialErrorMessage    string     `json:"initial_error_message"`
+	ErrorMessage           string     `json:"error_message"`
+	ErrorCode              string     `json:"error_code"`
+	Retryable              bool       `json:"retryable"`
+	Capturable             bool       `json:"capturable"`
+	EventIngestedAt        *time.Time `json:"event_ingested_at,omitempty"`
+	EventAgeSeconds        *int64     `json:"event_age_seconds,omitempty"`
+	RetryWindowSeconds     *int64     `json:"retry_window_seconds,omitempty"`
+	ExpiredRetryWindow     bool       `json:"expired_retry_window"`
+	OrganizationID         string     `json:"organization_id"`
+	ExternalSubscriptionID string     `json:"external_subscription_id"`
+	TransactionID          string     `json:"transaction_id"`
+	Code                   string     `json:"code"`
+	FailedAt               time.Time  `json:"failed_at"`
 }
 
 func (ev *Event) ToEnrichedEvent() utils.Result[*EnrichedEvent] {

--- a/events-processor/processors/events_processor/enrichment_service.go
+++ b/events-processor/processors/events_processor/enrichment_service.go
@@ -3,6 +3,7 @@ package events_processor
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/getlago/lago-expression/expression-go"
 	"github.com/getlago/lago/events-processor/cache"
@@ -58,6 +59,19 @@ func (s *EventEnrichmentService) EnrichEvent(event *models.Event) utils.Result[[
 	if subResult.Failure() {
 		if subResult.IsCapturable() {
 			return failedMultiEventsResult(subResult, "fetch_subscription", "Error fetching subscription")
+		}
+
+		if event.ExternalSubscriptionID != "" {
+			err := fmt.Errorf(
+				"no active subscription found for external_subscription_id %q at event timestamp %s",
+				event.ExternalSubscriptionID,
+				enrichedEvent.Time.Format(time.RFC3339Nano),
+			)
+			return failedMultiEventsResult(
+				utils.FailedResult[*models.Subscription](err).NonCapturable(),
+				"subscription_not_found",
+				"No active subscription matched the event external_subscription_id at the event timestamp",
+			)
 		}
 
 		subResult = utils.SuccessResult[*models.Subscription](nil)

--- a/events-processor/processors/events_processor/event_producer_service.go
+++ b/events-processor/processors/events_processor/event_producer_service.go
@@ -61,13 +61,7 @@ func (eps *EventProducerService) ProduceChargedInAdvanceEvent(context context.Co
 }
 
 func (eps *EventProducerService) ProduceToDeadLetterQueue(context context.Context, event models.Event, errorResult utils.AnyResult) {
-	failedEvent := models.FailedEvent{
-		Event:               event,
-		InitialErrorMessage: errorResult.ErrorMsg(),
-		ErrorCode:           errorResult.ErrorCode(),
-		ErrorMessage:        errorResult.ErrorMessage(),
-		FailedAt:            time.Now(),
-	}
+	failedEvent := buildFailedEvent(event, errorResult, time.Now())
 
 	eventJson, err := json.Marshal(failedEvent)
 	if err != nil {
@@ -82,6 +76,46 @@ func (eps *EventProducerService) ProduceToDeadLetterQueue(context context.Contex
 	if !pushed {
 		slog.Error("error while pushing to dead letter topic", slog.String("topic", eps.deadLetterProducer.GetTopic()))
 		utils.CaptureErrorResultWithExtra(errorResult, "event", event)
+	}
+}
+
+func buildFailedEvent(event models.Event, errorResult utils.AnyResult, failedAt time.Time) models.FailedEvent {
+	var eventIngestedAt *time.Time
+	var eventAgeSeconds *int64
+	var retryWindowSeconds *int64
+	expiredRetryWindow := false
+
+	if ingestedAt := event.IngestedAt.Time(); !ingestedAt.IsZero() {
+		eventIngestedAt = &ingestedAt
+		age := int64(failedAt.Sub(ingestedAt).Seconds())
+		if age < 0 {
+			age = 0
+		}
+		eventAgeSeconds = &age
+
+		if errorResult.IsRetryable() {
+			window := int64(maxRetryableEventAge.Seconds())
+			retryWindowSeconds = &window
+			expiredRetryWindow = failedAt.Sub(ingestedAt) >= maxRetryableEventAge
+		}
+	}
+
+	return models.FailedEvent{
+		Event:                  event,
+		InitialErrorMessage:    errorResult.ErrorMsg(),
+		ErrorCode:              errorResult.ErrorCode(),
+		ErrorMessage:           errorResult.ErrorMessage(),
+		Retryable:              errorResult.IsRetryable(),
+		Capturable:             errorResult.IsCapturable(),
+		EventIngestedAt:        eventIngestedAt,
+		EventAgeSeconds:        eventAgeSeconds,
+		RetryWindowSeconds:     retryWindowSeconds,
+		ExpiredRetryWindow:     expiredRetryWindow,
+		OrganizationID:         event.OrganizationID,
+		ExternalSubscriptionID: event.ExternalSubscriptionID,
+		TransactionID:          event.TransactionID,
+		Code:                   event.Code,
+		FailedAt:               failedAt,
 	}
 }
 

--- a/events-processor/processors/events_processor/event_producer_service_test.go
+++ b/events-processor/processors/events_processor/event_producer_service_test.go
@@ -210,9 +210,11 @@ func TestProduceToDeadLetterQueue(t *testing.T) {
 		ExternalSubscriptionID: "sub_id",
 		Code:                   "api_calls",
 		TransactionID:          "transaction_id",
+		IngestedAt:             utils.CustomTime(time.Now().Add(-2 * time.Minute)),
 	}
 
 	result := utils.FailedResult[string](fmt.Errorf("Error Message"))
+	result = result.AddErrorDetails("sample_error", "Sample error message")
 	producerService.ProduceToDeadLetterQueue(context.Background(), event, result)
 
 	var producedEvent models.FailedEvent
@@ -223,7 +225,17 @@ func TestProduceToDeadLetterQueue(t *testing.T) {
 
 	assert.Equal(t, event, producedEvent.Event)
 	assert.Equal(t, "Error Message", producedEvent.InitialErrorMessage)
-	assert.Equal(t, "", producedEvent.ErrorCode)
-	assert.Equal(t, "", producedEvent.ErrorMessage)
+	assert.Equal(t, "sample_error", producedEvent.ErrorCode)
+	assert.Equal(t, "Sample error message", producedEvent.ErrorMessage)
+	assert.True(t, producedEvent.Retryable)
+	assert.True(t, producedEvent.Capturable)
+	assert.False(t, producedEvent.ExpiredRetryWindow)
+	assert.Equal(t, event.OrganizationID, producedEvent.OrganizationID)
+	assert.Equal(t, event.ExternalSubscriptionID, producedEvent.ExternalSubscriptionID)
+	assert.Equal(t, event.TransactionID, producedEvent.TransactionID)
+	assert.Equal(t, event.Code, producedEvent.Code)
+	assert.NotNil(t, producedEvent.EventIngestedAt)
+	assert.NotNil(t, producedEvent.EventAgeSeconds)
+	assert.NotNil(t, producedEvent.RetryWindowSeconds)
 	assert.WithinDuration(t, time.Now(), producedEvent.FailedAt, 5*time.Second)
 }

--- a/events-processor/processors/events_processor/processor.go
+++ b/events-processor/processors/events_processor/processor.go
@@ -22,6 +22,8 @@ type EventProcessor struct {
 	CacheService      *CacheService
 }
 
+const maxRetryableEventAge = 12 * time.Hour
+
 func NewEventProcessor(enrichmentService *EventEnrichmentService, producerService *EventProducerService, refreshService *SubscriptionRefreshService, cacheService *CacheService) *EventProcessor {
 	return &EventProcessor{
 		EnrichmentService: enrichmentService,
@@ -73,7 +75,7 @@ func (processor *EventProcessor) ProcessEvents(ctx context.Context, records []*k
 						utils.CaptureErrorResultWithExtra(result, "event", event)
 					}
 
-					if result.IsRetryable() && time.Since(event.IngestedAt.Time()) < 12*time.Hour {
+					if result.IsRetryable() && !retryWindowExpired(event, time.Now()) {
 						// For retryable errors, we should avoid commiting the record,
 						// It will be consumed again and reprocessed
 						// Events older than 12 hours should also be pushed dead letter queue
@@ -96,6 +98,14 @@ func (processor *EventProcessor) ProcessEvents(ctx context.Context, records []*k
 
 	g.Wait()
 	return processedRecords
+}
+
+func retryWindowExpired(event models.Event, now time.Time) bool {
+	ingestedAt := event.IngestedAt.Time()
+	if ingestedAt.IsZero() {
+		return true
+	}
+	return now.Sub(ingestedAt) >= maxRetryableEventAge
 }
 
 func (processor *EventProcessor) processEvent(ctx context.Context, event *models.Event) utils.Result[*models.EnrichedEvent] {

--- a/events-processor/processors/events_processor/processor_test.go
+++ b/events-processor/processors/events_processor/processor_test.go
@@ -2,6 +2,7 @@ package events_processor
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
 	"gorm.io/gorm"
 
 	"github.com/getlago/lago/events-processor/cache"
@@ -210,6 +212,90 @@ func setupProcessorTestEnv(t *testing.T, useCache bool) *ProcessorTestEnv {
 	}
 }
 
+func TestProcessEventsRetriesUnresolvedUsageEventsBeforeDeadLettering(t *testing.T) {
+	testEnv := setupProcessorTestEnv(t, false)
+	defer testEnv.Cleanup()
+
+	event := models.Event{
+		OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+		ExternalSubscriptionID: "sub_id",
+		Code:                   "api_calls",
+		TransactionID:          "txn_retry",
+		Timestamp:              1741007009,
+		Source:                 "SQS",
+		IngestedAt:             utils.CustomTime(time.Now().Add(-time.Minute)),
+	}
+
+	testEnv.DataStore.SetBillableMetric(&models.BillableMetric{
+		ID:              "bm123",
+		OrganizationID:  event.OrganizationID,
+		Code:            event.Code,
+		AggregationType: models.AggregationTypeCount,
+		FieldName:       "api_requests",
+		CreatedAt:       utils.NowNullTime(),
+		UpdatedAt:       utils.NowNullTime(),
+	})
+	testEnv.DataStore.ExpectSubscriptionNotFound()
+
+	eventJSON, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	processed := testEnv.EventProcessor.ProcessEvents(context.Background(), []*kgo.Record{{Value: eventJSON}})
+
+	assert.Empty(t, processed)
+	assert.Equal(t, 0, testEnv.Producers.deadLetterProducer.ExecutionCount)
+}
+
+func TestProcessEventsDeadLettersExpiredUnresolvedUsageEventsWithRetryMetadata(t *testing.T) {
+	testEnv := setupProcessorTestEnv(t, false)
+	defer testEnv.Cleanup()
+
+	event := models.Event{
+		OrganizationID:         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+		ExternalSubscriptionID: "sub_id",
+		Code:                   "api_calls",
+		TransactionID:          "txn_expired",
+		Timestamp:              1741007009,
+		Source:                 "SQS",
+		IngestedAt:             utils.CustomTime(time.Now().Add(-maxRetryableEventAge - time.Minute)),
+	}
+
+	testEnv.DataStore.SetBillableMetric(&models.BillableMetric{
+		ID:              "bm123",
+		OrganizationID:  event.OrganizationID,
+		Code:            event.Code,
+		AggregationType: models.AggregationTypeCount,
+		FieldName:       "api_requests",
+		CreatedAt:       utils.NowNullTime(),
+		UpdatedAt:       utils.NowNullTime(),
+	})
+	testEnv.DataStore.ExpectSubscriptionNotFound()
+
+	eventJSON, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	record := &kgo.Record{Value: eventJSON}
+	processed := testEnv.EventProcessor.ProcessEvents(context.Background(), []*kgo.Record{record})
+
+	require.Len(t, processed, 1)
+	assert.Equal(t, record, processed[0])
+	assert.Equal(t, 1, testEnv.Producers.deadLetterProducer.ExecutionCount)
+
+	var failedEvent models.FailedEvent
+	require.NoError(t, json.Unmarshal(testEnv.Producers.deadLetterProducer.Value, &failedEvent))
+	assert.Equal(t, "subscription_not_found", failedEvent.ErrorCode)
+	assert.True(t, failedEvent.Retryable)
+	assert.False(t, failedEvent.Capturable)
+	assert.True(t, failedEvent.ExpiredRetryWindow)
+	assert.Equal(t, event.OrganizationID, failedEvent.OrganizationID)
+	assert.Equal(t, event.ExternalSubscriptionID, failedEvent.ExternalSubscriptionID)
+	assert.Equal(t, event.TransactionID, failedEvent.TransactionID)
+	require.NotNil(t, failedEvent.EventAgeSeconds)
+	require.NotNil(t, failedEvent.RetryWindowSeconds)
+	assert.GreaterOrEqual(t, *failedEvent.EventAgeSeconds, int64(maxRetryableEventAge.Seconds()))
+	assert.Equal(t, int64(maxRetryableEventAge.Seconds()), *failedEvent.RetryWindowSeconds)
+}
+
 func TestProcessEvent(t *testing.T) {
 	testModes := []struct {
 		name     string
@@ -336,7 +422,7 @@ func TestProcessEvent(t *testing.T) {
 			assert.Equal(t, "Error while converting event to enriched event", result.ErrorMessage())
 		})
 
-		t.Run("When event source is not post process on API when no subscriptions are found", func(t *testing.T) {
+		t.Run("When event source is not post processed on API and subscription is not found", func(t *testing.T) {
 			testEnv := setupProcessorTestEnv(t, mode.useCache)
 			defer testEnv.Cleanup()
 
@@ -362,7 +448,21 @@ func TestProcessEvent(t *testing.T) {
 			testEnv.DataStore.ExpectSubscriptionNotFound()
 
 			result := testEnv.EventProcessor.processEvent(context.Background(), &event)
-			assert.True(t, result.Success())
+			assert.False(t, result.Success())
+			assert.True(t, result.IsRetryable())
+			assert.False(t, result.IsCapturable())
+			assert.Equal(t, "subscription_not_found", result.ErrorCode())
+			assert.Equal(
+				t,
+				"No active subscription matched the event external_subscription_id at the event timestamp",
+				result.ErrorMessage(),
+			)
+			assert.Contains(t, result.ErrorMsg(), `external_subscription_id "sub_id"`)
+
+			time.Sleep(50 * time.Millisecond)
+			assert.Equal(t, 0, testEnv.Producers.enrichedProducer.ExecutionCount)
+			assert.Equal(t, 0, testEnv.Producers.enrichedExpandedProducer.ExecutionCount)
+			assert.Equal(t, 0, testEnv.FlagStore.ExecutionCount)
 		})
 
 		t.Run("When event source is not post process on API when expression failed to evaluate", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Usage events can arrive before the subscription cache or database view has caught up. Before this change, a non API post-processed event with an external subscription id but no active subscription match could be treated as successfully enriched without a subscription. That risks committing a billable usage event without producing the downstream enriched records needed for billing.

This PR changes that path to a retryable, non-capturable subscription_not_found failure while the event is still inside the retry window. If the event ages out, it goes to the dead letter topic with enough metadata to understand and replay it safely.

What changed:

- Return subscription_not_found when a usage event has an external subscription id but no active subscription at the event timestamp
- Replace the hard-coded retry-age check with a named retry window helper
- Add DLQ metadata for retryable, capturable, event age, retry window, expired retry window, org id, subscription external id, transaction id, and metric code
- Add tests for young unresolved events staying uncommitted and expired unresolved events going to DLQ with retry metadata

## Validation

- /tmp/codex-go/go/bin/gofmt -w on changed Go files
- git diff --check

I also tried go test -vet=off ./processors/events_processor ./models from events-processor using a temporary Go toolchain. The local machine is almost out of disk space and the build failed before compiling these packages with no space left on device while writing Go build artifacts. The failure was environmental, not a test assertion failure.
