### PR TITLE
chore: remove FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-custom: ['https://buy.stripe.com/7sIg2X2PVaA96v65kl']


### PR DESCRIPTION
Removes the `.github/FUNDING.yml` sponsor link.