### PR TITLE
doc(wallet): Document LAGO_WALLET_ONGOING_BALANCE_REFRESH_INTERVAL_SECONDS

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -324,7 +324,7 @@ Lago uses Clockwork to schedule recurring jobs. The clock process runs independe
 | Refresh Draft Invoices | Every 5 minutes | Updates draft invoice data | - |
 | Process Subscription Activity | Configurable (default: 1 minute) | Processes subscription activities | `LAGO_SUBSCRIPTION_ACTIVITY_PROCESSING_INTERVAL_SECONDS` |
 | Refresh Lifetime Usages | Configurable (default: 5 minutes) | Refreshes lifetime usage data | `LAGO_LIFETIME_USAGE_REFRESH_INTERVAL_SECONDS`, disable with `LAGO_DISABLE_LIFETIME_USAGE_REFRESH=true` |
-| Refresh Wallets Ongoing Balance | Every 5 minutes | Updates wallet balances | Requires cache configuration (`LAGO_MEMCACHE_SERVERS` or `LAGO_REDIS_CACHE_URL`), disable with `LAGO_DISABLE_WALLET_REFRESH=true` |
+| Refresh Wallets Ongoing Balance | Configurable (default: 5 minutes) | Updates wallet balances | Requires cache configuration (`LAGO_MEMCACHE_SERVERS` or `LAGO_REDIS_CACHE_URL`), disable with `LAGO_DISABLE_WALLET_REFRESH=true`, change interval with `LAGO_WALLET_ONGOING_BALANCE_REFRESH_INTERVAL_SECONDS` |
 | Refresh Flagged Subscriptions | Every 1 minute | Refreshes flagged subscriptions | Requires `LAGO_REDIS_STORE_URL` |
 
 #### Hourly Jobs


### PR DESCRIPTION
## Description

This PR adds the doc for the `LAGO_WALLET_ONGOING_BALANCE_REFRESH_INTERVAL_SECONDS` used to configure the refresh interval for the ongoing balance in the `clock` container.