### PR TITLE
[ING-493] fix(alerts): flag subscriptions for refresh on past recurring events

### DIFF
--- a/events-processor/models/billable_metrics.go
+++ b/events-processor/models/billable_metrics.go
@@ -48,6 +48,7 @@ type BillableMetric struct {
 	OrganizationID  string          `gorm:"->" json:"organization_id"`
 	Code            string          `gorm:"->" json:"code"`
 	AggregationType AggregationType `gorm:"->" json:"aggregation_type"`
+	Recurring       bool            `gorm:"->" json:"recurring"`
 	FieldName       string          `gorm:"->" json:"field_name"`
 	Expression      string          `gorm:"->" json:"expression"`
 	CreatedAt       utils.NullTime  `gorm:"->" json:"created_at"`
@@ -89,6 +90,7 @@ func GetAllBillableMetrics(db *gorm.DB) utils.Result[[]BillableMetric] {
 			"organization_id",
 			"code",
 			"aggregation_type",
+			"recurring",
 			"field_name",
 			"expression",
 			"created_at",

--- a/events-processor/models/billable_metrics_test.go
+++ b/events-processor/models/billable_metrics_test.go
@@ -53,6 +53,38 @@ func TestFetchBillableMetric(t *testing.T) {
 		assert.Equal(t, AggregationType(0), metric.AggregationType)
 		assert.Equal(t, "api_requests", metric.FieldName)
 		assert.Equal(t, "count", metric.Expression)
+		assert.False(t, metric.Recurring)
+	})
+
+	t.Run("should return recurring billable metric when found", func(t *testing.T) {
+		// Setup
+		store, mock, cleanup := setupApiStore(t)
+		defer cleanup()
+
+		orgID := "1a901a90-1a90-1a90-1a90-1a901a901a90"
+		code := "api_calls"
+		now := time.Now()
+
+		// Define expected rows and columns, including the recurring flag
+		columns := []string{"id", "organization_id", "code", "aggregation_type", "recurring", "field_name", "expression", "created_at", "updated_at", "deleted_at"}
+		rows := sqlmock.NewRows(columns).
+			AddRow("bm123", orgID, code, 0, true, "api_requests", "count", now, now, nil)
+
+		// Expect the query
+		mock.ExpectQuery(fetchBillableMetricQuery).
+			WithArgs(orgID, code, 1).
+			WillReturnRows(rows)
+
+		// Execute
+		result := store.FetchBillableMetric(orgID, code)
+
+		// Assert
+		assert.True(t, result.Success())
+
+		metric := result.Value()
+		assert.NotNil(t, metric)
+		assert.Equal(t, "bm123", metric.ID)
+		assert.True(t, metric.Recurring)
 	})
 
 	t.Run("should return error when billable metric not found", func(t *testing.T) {

--- a/events-processor/processors/events_processor/enrichment_service.go
+++ b/events-processor/processors/events_processor/enrichment_service.go
@@ -3,6 +3,7 @@ package events_processor
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/getlago/lago-expression/expression-go"
 	"github.com/getlago/lago/events-processor/cache"
@@ -48,11 +49,12 @@ func (s *EventEnrichmentService) EnrichEvent(event *models.Event) utils.Result[[
 		}
 	}
 
-	var subResult utils.Result[*models.Subscription]
-	if s.memCache != nil {
-		subResult = s.memCache.SearchSubscriptions(event.OrganizationID, event.ExternalSubscriptionID, enrichedEvent.Time)
-	} else {
-		subResult = s.apiStore.FetchSubscription(event.OrganizationID, event.ExternalSubscriptionID, enrichedEvent.Time)
+	subResult := s.fetchSubscription(event, enrichedEvent.Time)
+
+	// For recurring billable metrics, if no subscription is active at the event
+	// timestamp, fall back on the currently active subscription rather than failing.
+	if subResult.Failure() && !subResult.IsCapturable() && bm != nil && bm.Recurring {
+		subResult = s.fetchSubscription(event, time.Now())
 	}
 
 	if subResult.Failure() {
@@ -73,6 +75,13 @@ func (s *EventEnrichmentService) EnrichEvent(event *models.Event) utils.Result[[
 
 	enrichedEvents := s.enrichWithChargeInfo(enrichedEvent)
 	return enrichedEvents
+}
+
+func (s *EventEnrichmentService) fetchSubscription(event *models.Event, timestamp time.Time) utils.Result[*models.Subscription] {
+	if s.memCache != nil {
+		return s.memCache.SearchSubscriptions(event.OrganizationID, event.ExternalSubscriptionID, timestamp)
+	}
+	return s.apiStore.FetchSubscription(event.OrganizationID, event.ExternalSubscriptionID, timestamp)
 }
 
 func (s *EventEnrichmentService) enrichWithBillableMetric(enrichedEvent *models.EnrichedEvent, bm *models.BillableMetric) utils.Result[*models.EnrichedEvent] {

--- a/events-processor/processors/events_processor/enrichment_service_test.go
+++ b/events-processor/processors/events_processor/enrichment_service_test.go
@@ -904,6 +904,109 @@ func TestEnrichEvent(t *testing.T) {
 				assert.Equal(t, "charge_id1", *eventResult.ChargeID)
 				assert.Equal(t, map[string]string{"country": "", "type": ""}, eventResult.GroupedBy)
 			})
+
+			t.Run("With a recurring billable metric and no subscription active at the event timestamp", func(t *testing.T) {
+				testEnv := setupEnrichmentTestEnv(t, mode.useCache)
+				defer testEnv.Cleanup()
+
+				orgID := "1a901a90-1a90-1a90-1a90-1a901a901a90"
+
+				// Event dated 2025-03-03
+				event := models.Event{
+					OrganizationID:         orgID,
+					ExternalSubscriptionID: "sub_id",
+					Code:                   "api_calls",
+					Timestamp:              1741007009.0,
+					Source:                 "SQS",
+				}
+
+				bm := &models.BillableMetric{
+					ID:              "bm123",
+					OrganizationID:  event.OrganizationID,
+					Code:            event.Code,
+					AggregationType: models.AggregationTypeCount,
+					Recurring:       true,
+					CreatedAt:       utils.NowNullTime(),
+					UpdatedAt:       utils.NowNullTime(),
+				}
+				testEnv.DataStore.SetBillableMetric(bm)
+
+				// Subscription started after the event timestamp but is currently active,
+				// so it is only found when falling back on time.Now().
+				sub := &models.Subscription{
+					ID:             "sub123",
+					OrganizationID: &event.OrganizationID,
+					ExternalID:     event.ExternalSubscriptionID,
+					PlanID:         "plan_id",
+					StartedAt:      utils.NewNullTime(time.Unix(1751000000, 0)),
+				}
+				// First lookup (event timestamp) misses, fallback lookup (now) hits.
+				testEnv.DataStore.ExpectSubscriptionNotFound()
+				testEnv.DataStore.SetSubscription(sub)
+				testEnv.DataStore.SetFlatFilters([]*models.FlatFilter{})
+
+				enrichResult := testEnv.EventProcessor.EnrichEvent(&event)
+				assert.True(t, enrichResult.Success())
+				assert.Equal(t, 1, len(enrichResult.Value()))
+
+				eventResult := enrichResult.Value()[0]
+				assert.NotNil(t, eventResult.Subscription)
+				assert.Equal(t, "sub123", eventResult.SubscriptionID)
+				assert.Equal(t, "plan_id", eventResult.PlanID)
+			})
+
+			t.Run("With a non-recurring billable metric and no subscription active at the event timestamp", func(t *testing.T) {
+				testEnv := setupEnrichmentTestEnv(t, mode.useCache)
+				defer testEnv.Cleanup()
+
+				orgID := "1a901a90-1a90-1a90-1a90-1a901a901a90"
+
+				event := models.Event{
+					OrganizationID:         orgID,
+					ExternalSubscriptionID: "sub_id",
+					Code:                   "api_calls",
+					Timestamp:              1741007009.0,
+					Source:                 "SQS",
+				}
+
+				bm := &models.BillableMetric{
+					ID:              "bm123",
+					OrganizationID:  event.OrganizationID,
+					Code:            event.Code,
+					AggregationType: models.AggregationTypeCount,
+					Recurring:       false,
+					CreatedAt:       utils.NowNullTime(),
+					UpdatedAt:       utils.NowNullTime(),
+				}
+				testEnv.DataStore.SetBillableMetric(bm)
+
+				// A currently active subscription exists but started after the event
+				// timestamp. Since the metric is not recurring, no fallback happens and
+				// the event is enriched without a subscription (a single lookup, at the
+				// event timestamp, that misses).
+				if mode.useCache {
+					// In cache mode the timestamp filtering excludes the subscription
+					// because it started after the event timestamp.
+					sub := &models.Subscription{
+						ID:             "sub123",
+						OrganizationID: &event.OrganizationID,
+						ExternalID:     event.ExternalSubscriptionID,
+						PlanID:         "plan_id",
+						StartedAt:      utils.NewNullTime(time.Unix(1751000000, 0)),
+					}
+					testEnv.DataStore.SetSubscription(sub)
+				} else {
+					testEnv.DataStore.ExpectSubscriptionNotFound()
+				}
+
+				enrichResult := testEnv.EventProcessor.EnrichEvent(&event)
+				assert.True(t, enrichResult.Success())
+				assert.Equal(t, 1, len(enrichResult.Value()))
+
+				eventResult := enrichResult.Value()[0]
+				assert.Nil(t, eventResult.Subscription)
+				assert.Equal(t, "", eventResult.SubscriptionID)
+			})
 		})
 	}
 }

--- a/events-processor/processors/events_processor/processor_test.go
+++ b/events-processor/processors/events_processor/processor_test.go
@@ -110,9 +110,9 @@ type MockDataStore struct {
 }
 
 func (s *MockDataStore) SetBillableMetric(bm *models.BillableMetric) {
-	columns := []string{"id", "organization_id", "code", "aggregation_type", "field_name", "expression", "created_at", "updated_at", "deleted_at"}
+	columns := []string{"id", "organization_id", "code", "aggregation_type", "recurring", "field_name", "expression", "created_at", "updated_at", "deleted_at"}
 	rows := sqlmock.NewRows(columns).
-		AddRow(bm.ID, bm.OrganizationID, bm.Code, bm.AggregationType, bm.FieldName, bm.Expression, bm.CreatedAt, bm.UpdatedAt, bm.DeletedAt)
+		AddRow(bm.ID, bm.OrganizationID, bm.Code, bm.AggregationType, bm.Recurring, bm.FieldName, bm.Expression, bm.CreatedAt, bm.UpdatedAt, bm.DeletedAt)
 	s.mock.SQLMock.ExpectQuery("SELECT \\* FROM \"billable_metrics\".*").WillReturnRows(rows)
 }
 


### PR DESCRIPTION
## Context

Past-dated events (backfilled or late-arriving) failed enrichment when no subscription was active at the event timestamp.
For recurring billable metrics this is incorrect — recurring usage should still attach to the customer's current subscription even when the event predates it.
As a result, past-usage alerting and wallet refresh was silently dropped.

## Description

When the subscription lookup fails at the event timestamp, and the billable metric is recurring and the failure is non-capturable (no active subscription at that time), the enrichment now falls back to the currently active subscription (`time.Now()`) instead of failing the event.
Non-recurring metrics keep the existing strict behavior.

Supporting changes:
- Extracted a `fetchSubscription(event, timestamp)` helper to dedupe the `memCache` / `apiStore` branch, now reused for both lookups.
- Added the `Recurring` field to the `BillableMetric` model and included recurring in the `GetAllBillableMetrics` column selection so the flag is available during enrichment.