### PR TITLE
Migrate events-processor image build to centralized workflow

### DIFF
--- a/.github/workflows/build-processors-image.yaml
+++ b/.github/workflows/build-processors-image.yaml
@@ -9,34 +9,15 @@ on:
 
 jobs:
   build-processor-image:
-    runs-on: ubuntu-latest
     name: Build Events Processor Image
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Set short sha
-        id: sha_short
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker tag
-        id: docker_tag
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lago-events-processor
-          IMAGE_TAG: ${{ steps.sha_short.outputs.sha_short }}
-        run: echo "tag=$(echo $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG)" >> $GITHUB_OUTPUT
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: ./events-processor
-          push: true
-          tags: ${{ steps.docker_tag.outputs.tag }}
+    uses: ./.github/workflows/docker-build-multi-arch.yaml
+    with:
+      image-name: 201661579678.dkr.ecr.us-east-1.amazonaws.com/lago-events-processor
+      registry: ecr
+      aws-region: us-east-1
+      platforms: amd64,arm64
+      context: events-processor
+      dockerfile: events-processor/Dockerfile
+    secrets:
+      registry-user: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      registry-token: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
- `build-processors-image.yaml` built `lago-events-processor` with a plain `docker/build-push-action` step and no `platforms` input, so the ECR image pushed on every push to `main` carried only an amd64 manifest.
- Migrated it to call the shared `docker-build-multi-arch.yaml` workflow with `registry: ecr` and `platforms: amd64,arm64`, the same way `build-connectors-image.yaml` already does.

## Test plan
- [ ] Merge and confirm the workflow run on `main` pushes an ECR manifest with both `linux/amd64` and `linux/arm64`.
- [ ] Separately decide whether `release-processors-image.yml` (Docker Hub, GitHub-release-triggered) is still needed now that the ECR path is multi-arch — left untouched here, tracked as an open question on INF-391.

Part of INF-366.