### PR TITLE
Add a push input to the multi-arch build workflow

### DIFF
--- a/.github/workflows/docker-build-multi-arch.yaml
+++ b/.github/workflows/docker-build-multi-arch.yaml
@@ -81,6 +81,12 @@ on:
         type: string
         default: ''
 
+      push:
+        description: 'Push the built image(s) to the registry. Set false for PR-only validation builds.'
+        required: false
+        type: boolean
+        default: true
+
     secrets:
       registry-user:
         description: 'Registry username or AWS Access Key ID'
@@ -277,7 +283,7 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           build-args: ${{ inputs.build-args }}
           secrets: ${{ secrets.build-secrets }}
-          outputs: type=image,name=${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push }}
           cache-from: ${{ inputs.cache-type != 'disabled' && format('type=registry,ref={0}:buildcache-{1}', inputs.image-name, matrix.arch) || '' }}
           cache-to: ${{ inputs.cache-type != 'disabled' && format('type=registry,ref={0}:buildcache-{1},mode=max', inputs.image-name, matrix.arch) || '' }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -299,6 +305,7 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs: [build]
+    if: ${{ inputs.push }}
     outputs:
       image-tag: ${{ steps.summary.outputs.image-tag }}
       digest: ${{ steps.inspect.outputs.digest }}


### PR DESCRIPTION
## Summary

- Add a `push` input to `docker-build-multi-arch.yaml`, default `true`.
- Skip the push in the build step, and skip the `merge` job, when `push` is `false`.
- No current caller passes this input, so every existing build keeps its current behavior.

## Why

`lago-self-billing` (INF-392) needs its pull-request build to check both
architectures without a push to ECR. The shared workflow has no build-only
mode today. This input adds that mode without a change for any other caller.

Part of the arm64 image-coverage audit in INF-366.

## Test plan

- [ ] Confirm this PR's own CI (if it exercises the workflow) still passes with the default `push: true` path.
- [ ] After merge, confirm the `lago-self-billing` PR (getlago/lago-self-billing#TBD) builds both architectures on a pull request with no push, and pushes the merged manifest on merge to main.
