### PR TITLE
Support OIDC role assumption for ECR pushes

### DIFF
--- a/.github/workflows/docker-build-multi-arch.yaml
+++ b/.github/workflows/docker-build-multi-arch.yaml
@@ -87,6 +87,12 @@ on:
         type: boolean
         default: true
 
+      role-to-assume:
+        description: 'ARN of an IAM role to assume via OIDC (registry: ecr). Preferred over registry-user/registry-token.'
+        required: false
+        type: string
+        default: ''
+
     secrets:
       registry-user:
         description: 'Registry username or AWS Access Key ID'
@@ -116,6 +122,11 @@ on:
       tag:
         description: 'The primary tag (sha-<short_sha> or combined tag if build args provided)'
         value: ${{ jobs.merge.outputs.tag }}
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write # ghcr.io push falls back to GITHUB_TOKEN when no registry-token secret is given
 
 jobs:
   prepare:
@@ -186,6 +197,7 @@ jobs:
         if: inputs.registry == 'ecr'
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          role-to-assume: ${{ inputs.role-to-assume }}
           aws-access-key-id: ${{ secrets.registry-user }}
           aws-secret-access-key: ${{ secrets.registry-token }}
           aws-region: ${{ inputs.aws-region }}
@@ -326,6 +338,7 @@ jobs:
         if: inputs.registry == 'ecr'
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          role-to-assume: ${{ inputs.role-to-assume }}
           aws-access-key-id: ${{ secrets.registry-user }}
           aws-secret-access-key: ${{ secrets.registry-token }}
           aws-region: ${{ inputs.aws-region }}


### PR DESCRIPTION
## Summary
- Add a `role-to-assume` input to the reusable multi-arch build workflow so a caller can push to ECR with an assumed OIDC role instead of a long-lived `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` secret pair.
- Declare `permissions: {contents: read, id-token: write, packages: write}` so the workflow can request an OIDC token while keeping the existing ECR, Docker Hub, and GHCR paths working — `packages: write` specifically keeps `release-images.yml`'s GHCR pushes working, since those rely on the implicit `GITHUB_TOKEN` fallback.

INF-398

## Test plan
- [x] Checked every current caller (`build-connectors-image.yaml`, `build-processors-image.yaml`, `release-images.yml`, and callers in lago-oauth-proxy, lago-license, lago-self-billing, lago-sidekiqs, lago-front, lago-data) — all keep working unchanged, since `role-to-assume` defaults to empty and static-key/`GITHUB_TOKEN` paths are preserved
- [ ] First real user: getlago/lago-oauth-proxy PR #38 and getlago/lago-license PR #57, once this merges to `main`