### PR TITLE
Point connectors build at docker.io, not the redpanda mirror

### DIFF
--- a/connectors/Dockerfile
+++ b/connectors/Dockerfile
@@ -1,3 +1,8 @@
-FROM docker.redpanda.com/redpandadata/connect:4.83.0
+# docker.redpanda.com mirrors Docker Hub, but the CI pull does not count as
+# authenticated Docker Hub traffic. The anonymous Docker Hub rate limit
+# applies, and GitHub-hosted runners share it across many workflows. Use
+# docker.io directly to avoid the 429 errors.
+# Docs: https://docs.redpanda.com/streaming/current/troubleshoot/errors-solutions/k-resolve-errors/
+FROM docker.io/redpandadata/connect:4.83.0
 
 COPY *.yml ./


### PR DESCRIPTION
## Summary

- `build-connectors-image.yaml` failed twice with a 429 from
  `docker.redpanda.com` while it pulled the base image
  (runs on 2026-08-25 and 2026-08-26).
- `docker.redpanda.com` mirrors Docker Hub for download tracking, but
  buildx does not treat a pull through it as authenticated Docker Hub
  traffic. The anonymous Docker Hub rate limit still applies, and it
  is shared across every GitHub-hosted runner.
- Point the base image at `docker.io/redpandadata/connect` directly,
  the workaround Redpanda's own docs give for this mirror behavior.

## Evidence

- Failed run: https://github.com/getlago/lago/actions/runs/32959280415
- Failed run: https://github.com/getlago/lago/actions/runs/32824506432
- Redpanda docs on this rate-limit behavior: https://docs.redpanda.com/streaming/current/troubleshoot/errors-solutions/k-resolve-errors/

## Linear

- https://linear.app/getlago/issue/INF-395 (find the build pipeline for lago-connectors)
- https://linear.app/getlago/issue/INF-366 (parent audit: arm64 image-coverage for the Graviton pilot)

## Test plan

- [ ] Trigger `workflow_dispatch` on `build-connectors-image.yaml` and confirm the build no longer 429s
- [ ] `docker manifest inspect` the new tag and confirm it carries both `amd64` and `arm64`
