### PR TITLE
fix(events-processor): scope redis ctx per event

### DIFF
--- a/events-processor/models/charge_cache.go
+++ b/events-processor/models/charge_cache.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -19,7 +20,7 @@ func NewChargeCache(cacheStore *Cacher) *ChargeCache {
 	}
 }
 
-func (cache *ChargeCache) Expire(ff *FlatFilter, subID string) utils.Result[bool] {
+func (cache *ChargeCache) Expire(ctx context.Context, ff *FlatFilter, subID string) utils.Result[bool] {
 	// Build cache key components
 	keyParts := []string{
 		"charge-usage",
@@ -40,5 +41,5 @@ func (cache *ChargeCache) Expire(ff *FlatFilter, subID string) utils.Result[bool
 	cacheKey := strings.Join(keyParts, "/")
 
 	// Remove the cache entry
-	return cache.CacheStore.ExpireKey(cacheKey)
+	return cache.CacheStore.ExpireKey(ctx, cacheKey)
 }

--- a/events-processor/models/charge_cache_test.go
+++ b/events-processor/models/charge_cache_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -30,7 +31,7 @@ func TestExpireChargeCache(t *testing.T) {
 		var cache Cacher = cacheStore
 		chargeCache := NewChargeCache(&cache)
 
-		result := chargeCache.Expire(&chargeFilter, subID)
+		result := chargeCache.Expire(context.Background(), &chargeFilter, subID)
 
 		assert.True(t, result.Success())
 		assert.Equal(t, cacheStore.LastKey, "charge-usage/1/charge_id/sub_id/2025-03-03T13:03:29Z")
@@ -60,7 +61,7 @@ func TestExpireChargeCache(t *testing.T) {
 		var cache Cacher = cacheStore
 		chargeCache := NewChargeCache(&cache)
 
-		result := chargeCache.Expire(&chargeFilter, subID)
+		result := chargeCache.Expire(context.Background(), &chargeFilter, subID)
 
 		assert.True(t, result.Success())
 		assert.Equal(t, cacheStore.LastKey, "charge-usage/1/charge_id/sub_id/2025-03-03T13:03:29Z/filter_id/2025-03-03T13:03:29Z")

--- a/events-processor/models/stores.go
+++ b/events-processor/models/stores.go
@@ -26,20 +26,18 @@ func NewApiStore(db *database.DB) *ApiStore {
 }
 
 type FlagStore struct {
-	name    string
-	context context.Context
-	db      *redis.RedisDB
+	name string
+	db   *redis.RedisDB
 }
 
 type Flagger interface {
-	Flag(value string) error
+	Flag(ctx context.Context, value string) error
 }
 
-func NewFlagStore(ctx context.Context, redis *redis.RedisDB, name string) *FlagStore {
+func NewFlagStore(redis *redis.RedisDB, name string) *FlagStore {
 	return &FlagStore{
-		name:    name,
-		context: ctx,
-		db:      redis,
+		name: name,
+		db:   redis,
 	}
 }
 
@@ -49,13 +47,17 @@ func NewFlagStore(ctx context.Context, redis *redis.RedisDB, name string) *FlagS
 // score to the latest event, waiting after the last event in that window.
 // Once the window elapses, new events create a new member, ensuring the
 // previous one ages out and gets picked up by the consumer (no starvation).
-func (store *FlagStore) Flag(value string) error {
+//
+// The context must be scoped to the record being processed, never to the
+// process lifetime: a process-wide context is canceled on shutdown, which
+// would fail the write for every event still in flight.
+func (store *FlagStore) Flag(ctx context.Context, value string) error {
 	now := time.Now().Unix()
 
 	// Calculate the bucket (time window) for the event
 	bucket := (now / SUBSCRIPTION_BUCKET_DURATION) * SUBSCRIPTION_BUCKET_DURATION
 
-	result := store.db.Client.ZAdd(store.context, store.name, goredis.Z{
+	result := store.db.Client.ZAdd(ctx, store.name, goredis.Z{
 		Score:  float64(now),
 		Member: fmt.Sprintf("%s|%d", value, bucket),
 	})
@@ -72,18 +74,16 @@ func (store *FlagStore) Close() error {
 
 type Cacher interface {
 	Close() error
-	ExpireKey(key string) utils.Result[bool]
+	ExpireKey(ctx context.Context, key string) utils.Result[bool]
 }
 
 type CacheStore struct {
-	context context.Context
-	db      *redis.RedisDB
+	db *redis.RedisDB
 }
 
-func NewCacheStore(ctx context.Context, redis *redis.RedisDB) *CacheStore {
+func NewCacheStore(redis *redis.RedisDB) *CacheStore {
 	return &CacheStore{
-		context: ctx,
-		db:      redis,
+		db: redis,
 	}
 }
 
@@ -91,9 +91,11 @@ func (store *CacheStore) Close() error {
 	return store.db.Client.Close()
 }
 
-func (store *CacheStore) ExpireKey(key string) utils.Result[bool] {
+// ExpireKey schedules the removal of a cache key. As for FlagStore.Flag, the
+// context must be scoped to the record being processed, not to the process.
+func (store *CacheStore) ExpireKey(ctx context.Context, key string) utils.Result[bool] {
 	// Uses Expire command rather than Del to take clickhouse propagation time into account
-	res := store.db.Client.Expire(store.context, key, EXPIRATION_TIME)
+	res := store.db.Client.Expire(ctx, key, EXPIRATION_TIME)
 	if err := res.Err(); err != nil {
 		return utils.FailedBoolResult(err)
 	}

--- a/events-processor/models/stores_test.go
+++ b/events-processor/models/stores_test.go
@@ -30,9 +30,8 @@ func setupFlagStore(t *testing.T, name string) (*FlagStore, *miniredis.Miniredis
 	s := miniredis.RunT(t)
 	client := goredis.NewClient(&goredis.Options{Addr: s.Addr()})
 	store := &FlagStore{
-		name:    name,
-		context: context.Background(),
-		db:      &redis.RedisDB{Client: client},
+		name: name,
+		db:   &redis.RedisDB{Client: client},
 	}
 	return store, s
 }
@@ -41,7 +40,7 @@ func TestFlag(t *testing.T) {
 	t.Run("adds member to sorted set with correct format", func(t *testing.T) {
 		store, s := setupFlagStore(t, "test_flags")
 
-		err := store.Flag("org1:sub1")
+		err := store.Flag(context.Background(), "org1:sub1")
 		assert.NoError(t, err)
 
 		members, err := s.ZMembers("test_flags")
@@ -60,7 +59,7 @@ func TestFlag(t *testing.T) {
 	t.Run("bucket follows SUBSCRIPTION_BUCKET_DURATION intervals", func(t *testing.T) {
 		store, s := setupFlagStore(t, "test_flags")
 
-		err := store.Flag("org1:sub1")
+		err := store.Flag(context.Background(), "org1:sub1")
 		assert.NoError(t, err)
 
 		members, err := s.ZMembers("test_flags")
@@ -77,9 +76,9 @@ func TestFlag(t *testing.T) {
 	t.Run("two calls in same window produce one member", func(t *testing.T) {
 		store, s := setupFlagStore(t, "test_flags")
 
-		err := store.Flag("org1:sub1")
+		err := store.Flag(context.Background(), "org1:sub1")
 		assert.NoError(t, err)
-		err = store.Flag("org1:sub1")
+		err = store.Flag(context.Background(), "org1:sub1")
 		assert.NoError(t, err)
 
 		members, err := s.ZMembers("test_flags")
@@ -90,9 +89,9 @@ func TestFlag(t *testing.T) {
 	t.Run("different values produce separate members", func(t *testing.T) {
 		store, s := setupFlagStore(t, "test_flags")
 
-		err := store.Flag("org1:sub1")
+		err := store.Flag(context.Background(), "org1:sub1")
 		assert.NoError(t, err)
-		err = store.Flag("org2:sub2")
+		err = store.Flag(context.Background(), "org2:sub2")
 		assert.NoError(t, err)
 
 		members, err := s.ZMembers("test_flags")
@@ -103,7 +102,7 @@ func TestFlag(t *testing.T) {
 	t.Run("new bucket after time window advances", func(t *testing.T) {
 		store, s := setupFlagStore(t, "test_flags")
 
-		err := store.Flag("org1:sub1")
+		err := store.Flag(context.Background(), "org1:sub1")
 		assert.NoError(t, err)
 
 		// Fast-forward miniredis past the merge delay window
@@ -124,7 +123,7 @@ func TestFlag(t *testing.T) {
 		store, s := setupFlagStore(t, "test_flags")
 
 		s.SetError("forced error")
-		err := store.Flag("org1:sub1")
+		err := store.Flag(context.Background(), "org1:sub1")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "forced error")
 	})

--- a/events-processor/processors/events_processor/cache_service.go
+++ b/events-processor/processors/events_processor/cache_service.go
@@ -1,6 +1,8 @@
 package events_processor
 
 import (
+	"context"
+
 	"github.com/getlago/lago/events-processor/models"
 	"github.com/getlago/lago/events-processor/utils"
 )
@@ -15,13 +17,13 @@ func NewCacheService(chargeCacheStore *models.ChargeCache) *CacheService {
 	}
 }
 
-func (s *CacheService) ExpireCache(events []*models.EnrichedEvent) {
+func (s *CacheService) ExpireCache(ctx context.Context, events []*models.EnrichedEvent) {
 	for _, event := range events {
 		if event.FlatFilter == nil {
 			continue
 		}
 
-		cacheResult := s.chargeCacheStore.Expire(event.FlatFilter, event.SubscriptionID)
+		cacheResult := s.chargeCacheStore.Expire(ctx, event.FlatFilter, event.SubscriptionID)
 		if cacheResult.Failure() {
 			utils.CaptureError(cacheResult.Error())
 		}

--- a/events-processor/processors/events_processor/cache_service_test.go
+++ b/events-processor/processors/events_processor/cache_service_test.go
@@ -1,6 +1,7 @@
 package events_processor
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -46,7 +47,7 @@ func TestExpireCache(t *testing.T) {
 			FlatFilter:             flatFilter,
 		}
 
-		cacheService.ExpireCache([]*models.EnrichedEvent{&event})
+		cacheService.ExpireCache(context.Background(), []*models.EnrichedEvent{&event})
 
 		assert.Equal(t, 1, cacheStore.ExecutionCount)
 	})
@@ -62,7 +63,7 @@ func TestExpireCache(t *testing.T) {
 			SubscriptionID:         "sub123",
 		}
 
-		cacheService.ExpireCache([]*models.EnrichedEvent{&event})
+		cacheService.ExpireCache(context.Background(), []*models.EnrichedEvent{&event})
 
 		assert.Equal(t, 0, cacheStore.ExecutionCount)
 	})
@@ -93,7 +94,7 @@ func TestExpireCache(t *testing.T) {
 			FlatFilter:             flatFilter,
 		}
 
-		cacheService.ExpireCache([]*models.EnrichedEvent{&event})
+		cacheService.ExpireCache(context.Background(), []*models.EnrichedEvent{&event})
 
 		assert.Equal(t, 1, cacheStore.ExecutionCount)
 	})
@@ -145,7 +146,7 @@ func TestExpireCache(t *testing.T) {
 			FlatFilter:             flatFilter2,
 		}
 
-		cacheService.ExpireCache([]*models.EnrichedEvent{&event1, &event2})
+		cacheService.ExpireCache(context.Background(), []*models.EnrichedEvent{&event1, &event2})
 
 		assert.Equal(t, 2, cacheStore.ExecutionCount)
 	})
@@ -184,7 +185,7 @@ func TestExpireCache(t *testing.T) {
 			SubscriptionID:         "sub123",
 		}
 
-		cacheService.ExpireCache([]*models.EnrichedEvent{&event1, &event2})
+		cacheService.ExpireCache(context.Background(), []*models.EnrichedEvent{&event1, &event2})
 
 		assert.Equal(t, 1, cacheStore.ExecutionCount)
 	})

--- a/events-processor/processors/events_processor/processor.go
+++ b/events-processor/processors/events_processor/processor.go
@@ -153,13 +153,13 @@ func (processor *EventProcessor) processEvent(ctx context.Context, event *models
 			})
 		}
 
-		flagResult := processor.RefreshService.FlagSubscriptionRefresh(enrichedEvent)
+		flagResult := processor.RefreshService.FlagSubscriptionRefresh(ctx, enrichedEvent)
 		if flagResult.Failure() {
 			return failedResult(flagResult, "flag_subscription_refresh", "Error flagging subscription refresh")
 		}
 
 		// Expire cache at charge and charge filter level
-		processor.CacheService.ExpireCache(enrichedEvents)
+		processor.CacheService.ExpireCache(ctx, enrichedEvents)
 	}
 
 	return utils.SuccessResult(enrichedEvent)

--- a/events-processor/processors/events_processor/subscription_refresh_service.go
+++ b/events-processor/processors/events_processor/subscription_refresh_service.go
@@ -1,6 +1,7 @@
 package events_processor
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/getlago/lago/events-processor/models"
@@ -17,8 +18,8 @@ func NewSubscriptionRefreshService(flagStore models.Flagger) *SubscriptionRefres
 	}
 }
 
-func (s *SubscriptionRefreshService) FlagSubscriptionRefresh(event *models.EnrichedEvent) utils.Result[bool] {
-	err := s.flagStore.Flag(fmt.Sprintf("%s:%s", event.OrganizationID, event.SubscriptionID))
+func (s *SubscriptionRefreshService) FlagSubscriptionRefresh(ctx context.Context, event *models.EnrichedEvent) utils.Result[bool] {
+	err := s.flagStore.Flag(ctx, fmt.Sprintf("%s:%s", event.OrganizationID, event.SubscriptionID))
 	if err != nil {
 		return utils.FailedBoolResult(err)
 	}

--- a/events-processor/processors/events_processor/subscription_refresh_service_test.go
+++ b/events-processor/processors/events_processor/subscription_refresh_service_test.go
@@ -1,6 +1,7 @@
 package events_processor
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -28,13 +29,13 @@ func TestFlagSubscriptionRefresh(t *testing.T) {
 		SubscriptionID: "sub_id",
 	}
 
-	result := refreshService.FlagSubscriptionRefresh(&event)
+	result := refreshService.FlagSubscriptionRefresh(context.Background(), &event)
 	assert.Equal(t, 1, flagStore.ExecutionCount)
 	assert.True(t, result.Success())
 	assert.True(t, result.Value())
 
 	flagStore.ReturnedError = fmt.Errorf("Failed to flag subscription")
-	result = refreshService.FlagSubscriptionRefresh(&event)
+	result = refreshService.FlagSubscriptionRefresh(context.Background(), &event)
 	assert.Equal(t, 2, flagStore.ExecutionCount)
 	assert.True(t, result.Failure())
 	assert.Error(t, result.Error())

--- a/events-processor/processors/main_processor.go
+++ b/events-processor/processors/main_processor.go
@@ -98,7 +98,7 @@ func initFlagStore(ctx context.Context, name string) (*models.FlagStore, error) 
 		return nil, err
 	}
 
-	return models.NewFlagStore(ctx, db, name), nil
+	return models.NewFlagStore(db, name), nil
 }
 
 func initChargeCacheStore(ctx context.Context) (*models.ChargeCache, error) {
@@ -119,7 +119,7 @@ func initChargeCacheStore(ctx context.Context) (*models.ChargeCache, error) {
 		return nil, err
 	}
 
-	cacheStore := models.NewCacheStore(ctx, db)
+	cacheStore := models.NewCacheStore(db)
 	var store models.Cacher = cacheStore
 	chargeStore := models.NewChargeCache(&store)
 

--- a/events-processor/tests/mocked_cache_store.go
+++ b/events-processor/tests/mocked_cache_store.go
@@ -1,6 +1,10 @@
 package tests
 
-import "github.com/getlago/lago/events-processor/utils"
+import (
+	"context"
+
+	"github.com/getlago/lago/events-processor/utils"
+)
 
 type MockCacheStore struct {
 	LastKey        string
@@ -12,7 +16,7 @@ func (mcs *MockCacheStore) Close() error {
 	return nil
 }
 
-func (mcs *MockCacheStore) ExpireKey(key string) utils.Result[bool] {
+func (mcs *MockCacheStore) ExpireKey(_ context.Context, key string) utils.Result[bool] {
 	mcs.LastKey = key
 	mcs.ExecutionCount++
 

--- a/events-processor/tests/mocked_flag_store.go
+++ b/events-processor/tests/mocked_flag_store.go
@@ -1,12 +1,14 @@
 package tests
 
+import "context"
+
 type MockFlagStore struct {
 	Key            string
 	ExecutionCount int
 	ReturnedError  error
 }
 
-func (mfs *MockFlagStore) Flag(key string) error {
+func (mfs *MockFlagStore) Flag(_ context.Context, key string) error {
 	mfs.ExecutionCount++
 	mfs.Key = key
 


### PR DESCRIPTION
## Context

`FlagStore` and `CacheStore` stored the context they were built with, and that context is the
process-wide one created in `main` and canceled on SIGTERM. Batch processing, on the other hand,
deliberately runs on a fresh `context.Background()` so a rolling restart lets in-flight records
finish instead of dropping them. The two never agreed: the batch kept going while every Redis
write inside it failed with `context canceled`.

Every restart therefore produced a burst of failures, one per record still being processed. The
events are safe, since the failure is retryable and the offset is not committed, but the failing
flag aborts the rest of `processEvent`, so charge usage cache keys are never expired for that
batch and stay warm until the next event on the same subscription.

## Description

The stores no longer hold a context; `Flagger.Flag` and `Cacher.ExpireKey` take one, and the
processor passes the context of the record it is working on. Suppressing `context.Canceled` at
capture time was the cheaper option and was rejected: it hides the log line while still skipping
cache expiration and still bouncing the batch back through Kafka.

Connection setup still uses the process context on purpose — a startup ping should die with the
process. Existing store and service tests only gained a context argument; no expectation changed.
