### PR TITLE
chore(meilisearch): remove meilisearch from the dev stack

### DIFF
--- a/.env.development.default
+++ b/.env.development.default
@@ -73,11 +73,6 @@ LAGO_ENCRYPTION_PRIMARY_KEY=your-encrpytion-primary-key
 LAGO_ENCRYPTION_DETERMINISTIC_KEY=your-encrpytion-deterministic-key
 LAGO_ENCRYPTION_KEY_DERIVATION_SALT=your-encrpytion-derivation-salt
 
-# Meilisearch
-LAGO_MEILISEARCH_SEARCH_ENABLED=true
-LAGO_MEILISEARCH_URL=http://meilisearch:7700
-LAGO_MEILISEARCH_API_KEY=masterKeyChangeMe
-
 # Kafka
 LAGO_KAFKA_BOOTSTRAP_SERVERS=redpanda:9092
 LAGO_KAFKA_RAW_EVENTS_TOPIC=events-raw

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,6 @@ volumes:
   redis_replica_data_dev:
   redpanda_data_dev:
   clickhouse_data_dev:
-  meilisearch_data_dev:
 
 services:
   traefik:
@@ -286,17 +285,6 @@ services:
         bundle install && ./scripts/start.ai_agent.worker.sh
       '
 
-  api-meilisearch-worker:
-    <<: *api_worker
-    container_name: lago_api_meilisearch_worker_dev
-    command: |
-      bash -c '
-        if [[ -n "$${SIDEKIQ_CONCURRENCY_MEILISEARCH}" ]]; then
-          export SIDEKIQ_CONCURRENCY=$${SIDEKIQ_CONCURRENCY_MEILISEARCH}
-        fi
-        bundle install && ./scripts/start.meilisearch.worker.sh
-      '
-
   api-clock:
     image: api_dev
     pull_policy: never
@@ -492,36 +480,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
-
-  meilisearch:
-    image: getmeili/meilisearch:v1.49
-    container_name: lago_meilisearch_dev
-    restart: unless-stopped
-    hostname: meilisearch
-    env_file:
-      - path: ./.env.development.default
-      - path: ./.env.development
-        required: false
-    environment:
-      - MEILI_ENV=development
-      - MEILI_MASTER_KEY=${LAGO_MEILISEARCH_API_KEY:-masterKeyChangeMe}
-      - MEILI_NO_ANALYTICS=true
-    volumes:
-      - meilisearch_data_dev:/meili_data
-    ports:
-      - 7700:7700
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:7700/health || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.meilisearch.rule=Host(`meilisearch.lago.dev`)"
-      - "traefik.http.routers.meilisearch.entrypoints=web,websecure"
-      - "traefik.http.routers.meilisearch.tls=true"
-      - "traefik.http.services.meilisearch.loadbalancer.server.port=7700"
 
   pghero:
     image: ankane/pghero:latest

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,7 +91,6 @@ Lago supports dedicated workers for specific job types to improve performance an
 | `SIDEKIQ_AI_AGENT`   | `ai_agent`                         | 10                               | AI Agent             |
 | `SIDEKIQ_ALERTS`     | `alerts_high_priority`, `alerts`   | 5                                | Usage Alerting       |
 | `SIDEKIQ_WALLETS`    | `wallets`                          | 10                               | Wallet balance refresh |
-| _(always on, no toggle)_ | `meilisearch`                  | 10                               | Meilisearch invoice indexing |
 
 #### Queue Routing Logic
 
@@ -221,7 +220,6 @@ Lago's production deployment includes multiple worker types, each handling speci
 | **Wallet Worker** | `wallets` | Refreshes wallet ongoing balances | Optional | Enable with `SIDEKIQ_WALLETS=true`; otherwise jobs fall back to `low_priority` |
 | **Alerts Worker** | `alerts_high_priority`, `alerts` | Processes usage alerting jobs | Optional | Enable with `SIDEKIQ_ALERTS=true`; otherwise jobs fall back to `default` |
 | **AI Agent Worker** | `ai_agent` | Handles AI Agent jobs | Optional | Enable with `SIDEKIQ_AI_AGENT=true` |
-| **Meilisearch Worker** | `meilisearch` | Indexes invoices into Meilisearch | Optional | Always routes to the `meilisearch` queue (no toggle); requires this worker when Meilisearch search is used |
 
 #### Specialized Workers
 


### PR DESCRIPTION
Drops the `meilisearch` service, the `api-meilisearch-worker`, its data volume, the `LAGO_MEILISEARCH_*` env vars and the two worker doc rows.

Companion to getlago/lago-api#6260, which removes Meilisearch from the API.