### PR TITLE
fix(events-processor): refresh usage cache for API post-processed events (#538)

### DIFF
--- a/events-processor/processors/events_processor/processor.go
+++ b/events-processor/processors/events_processor/processor.go
@@ -152,7 +152,9 @@ func (processor *EventProcessor) processEvent(ctx context.Context, event *models
 				return nil
 			})
 		}
+	}
 
+	if enrichedEvent.Subscription != nil {
 		flagResult := processor.RefreshService.FlagSubscriptionRefresh(ctx, enrichedEvent)
 		if flagResult.Failure() {
 			return failedResult(flagResult, "flag_subscription_refresh", "Error flagging subscription refresh")

--- a/events-processor/processors/events_processor/processor_test.go
+++ b/events-processor/processors/events_processor/processor_test.go
@@ -302,6 +302,8 @@ func TestProcessEvent(t *testing.T) {
 			time.Sleep(50 * time.Millisecond)
 			assert.Equal(t, 1, testEnv.Producers.enrichedProducer.ExecutionCount)
 			assert.Equal(t, 1, testEnv.Producers.enrichedExpandedProducer.ExecutionCount)
+			assert.Equal(t, 1, testEnv.FlagStore.ExecutionCount)
+			assert.Equal(t, 1, testEnv.CacheStore.ExecutionCount)
 		})
 
 		t.Run("When event source is not post process on API when timestamp is invalid", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Keep subscription refresh and usage cache expiry active for API post-processed events so newly ingested events are reflected in current usage. The in-advance charge path remains skipped for those events.

## Testing
- `git diff --check`
- `go version` could not run in this workspace because the Go toolchain is not installed

closes #538