### PR TITLE
chore(front): share one pnpm store between the front containers

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,11 @@ configs:
 volumes:
   front_node_modules_dev:
   front_dist_dev:
+  # Shared with the per-workspace Conductor front containers, which mount it on
+  # the same path (scripts/conductor-front-container.sh in the front repo).
+  # External so its name stays unprefixed and `down -v` never drops it.
+  lago_front_pnpm_store:
+    external: true
   postgres_data_dev:
   redis_data_dev:
   redis_replica_data_dev:
@@ -93,6 +98,10 @@ services:
       - ./front:/app:cached
       - front_node_modules_dev:/app/node_modules
       - front_dist_dev:/app/dist
+      # /app is a bind mount, so pnpm always relocates its store to
+      # <project>/.pnpm-store; mounting the shared volume there keeps ~670MB out
+      # of ./front and lets every workspace container reuse one store.
+      - lago_front_pnpm_store:/app/.pnpm-store
     environment:
       - NODE_ENV=development
       - API_URL=https://api.lago.dev


### PR DESCRIPTION
## Context

The front service and every per-workspace Conductor front container each kept their own pnpm store: ~670MB duplicated per checkout, and a full re-download of the store on every new workspace. Locally that was 5GB of pure duplication across six workspaces plus the main clone.

The placement is not free choice. `/app` is a bind mount, so pnpm refuses to keep its store on another device: it ignores `store-dir` env vars entirely (`npm_config_store_dir`, `NPM_CONFIG_STORE_DIR`, `PNPM_STORE_DIR` are all no-ops) and rewrites even an explicitly configured store back to `<project>/.pnpm-store`. Mounting a shared volume on that exact path is the only placement pnpm accepts.

## Description

Mounts `lago_front_pnpm_store` at `/app/.pnpm-store` on the front service, declared `external` so its name stays unprefixed - which is what makes it the *same* volume the per-workspace containers mount - and so a `down -v` can never drop it.

Companion PR in lago-front does the same for the Conductor workspace containers, alongside the archived-workspace teardown fix: https://github.com/getlago/lago-front/pull/4228

## Test plan

- `docker compose config` valid, both with this file alone and merged with the lago-license compose file.
- Full stack restarted: 27 containers up, vite ready, app serving HTTP 200.
- Verified on the running container: the mount resolves to `lago_front_pnpm_store -> /app/.pnpm-store`, and `pnpm store path` reports `/app/.pnpm-store/v10`.
- 5GB of duplicated stores reclaimed locally (3.9GB across workspaces, 1.1GB in the main clone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p5UL48WSkAmNs9RHLLEVL